### PR TITLE
fix badge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- badges: start -->
 
-[![Build Status](https://github.com/sipss/GCIMS/workflows/R-CMD-check-bioc/badge.svg?branch=master)](https://github.com/sipss/GCIMS/actions/)
+[![Build Status](https://github.com/sipss/GCIMS/actions/workflows/check-bioc.yml/badge.svg?branch=master)](https://github.com/sipss/GCIMS/actions/)
 [![Documentation](https://img.shields.io/badge/documentation-pkgdown-informational)](https://sipss.github.io/GCIMS/)
 
 <!-- badges: end -->


### PR DESCRIPTION
Hola @evamartin1240 

He corregido otra cosilla, un detalle tonto:

En el README hay una badge que muestra el estado de los tests del paquete. El código del README está mal y por eso siempre aparece como failing.

Con este pull request cambio el README para que muestre la imagen correcta.

Te pido que revises todo lo que hago porque creo que no está bien que yo haga cambios unilateralmente al paquete, sobretodo si vosotros estáis trabajando con el paquete o haciendo cualquier cosa.

Si te molesta me lo dices sin problema.

Saludos!