### PR TITLE
Add unit tests for align-GCIMSDataset.R; fix dt_kcorr crash

### DIFF
--- a/R/align-GCIMSDataset.R
+++ b/R/align-GCIMSDataset.R
@@ -92,8 +92,14 @@ setMethod(
 )
 
 .align_fun_extract <- function(x) {
+  dt_kcorr <- x@proc_params$align$dt_kcorr
+  if (is.null(dt_kcorr)) {
+    # prealign() (and therefore alignDt()) was skipped (align_dt = FALSE,
+    # align_ip = FALSE), so no drift-time correction was ever recorded.
+    dt_kcorr <- 1
+  }
   list(
-    dt_kcorr = x@proc_params$align$dt_kcorr,
+    dt_kcorr = dt_kcorr,
     w = x@proc_params$align$w
   )
 }

--- a/tests/testthat/test-align-GCIMSDataset.R
+++ b/tests/testthat/test-align-GCIMSDataset.R
@@ -1,0 +1,82 @@
+gauss <- function(rt, center, height, sd) height * exp(-(rt - center)^2 / (2 * sd^2))
+
+# A GCIMSSample whose single informative drift-time row (the RIP row) has
+# both an injection-point spike (early in rt, for align_ip) and an
+# analyte-elution dip (later in rt, for the ptw retention-time warp),
+# mirroring how getRIC()'s max(row)-row inversion turns a raw dip into a
+# RIC peak and a raw spike into a RIC minimum.
+make_rip_sample <- function(dt, rt, rip_idx, injection_rt, analyte_rt) {
+  data <- matrix(1, nrow = length(dt), ncol = length(rt))
+  data[rip_idx, ] <- 1000 + gauss(rt, injection_rt, 2000, 1.5) - gauss(rt, analyte_rt, 900, 3)
+  GCIMSSample(drift_time = dt, retention_time = rt, data = data)
+}
+
+make_dataset <- function() {
+  dt <- seq(1, 10, by = 0.5)
+  rt <- 1:80
+  s1 <- make_rip_sample(dt, rt, rip_idx = 10, injection_rt = 5, analyte_rt = 40)
+  s2 <- make_rip_sample(dt, rt, rip_idx = 8, injection_rt = 5, analyte_rt = 34)
+  s3 <- make_rip_sample(dt, rt, rip_idx = 12, injection_rt = 5, analyte_rt = 46)
+  GCIMSDataset$new_from_list(
+    samples = list(s1 = s1, s2 = s2, s3 = s3),
+    on_ram = TRUE,
+    scratch_dir = NULL
+  )
+}
+
+test_that("align() on a GCIMSDataset aligns retention time and drift time across samples", {
+  ds <- make_dataset()
+
+  align(ds, method_rt = "ptw", align_dt = TRUE, align_ip = TRUE)
+  ds$realize()
+
+  samples <- lapply(ds$sampleNames, ds$getSample)
+  for (s in samples) {
+    expect_false(anyNA(intensity(s)))
+  }
+
+  # align_ip assigns the very same rt_ref vector to every sample:
+  rt_lists <- lapply(samples, rtime)
+  expect_true(all(vapply(rt_lists[-1], identical, logical(1), rt_lists[[1]])))
+
+  # Drift-time correction was actually computed (samples had different RIP
+  # positions), not left at the trivial default:
+  expect_false(all(ds$align$dt_kcorr == 1))
+  expect_named(ds$align$dt_kcorr, ds$sampleNames)
+})
+
+test_that("align() honors an explicit reference_sample_idx", {
+  ds <- make_dataset()
+
+  align(ds, method_rt = "ptw", align_dt = TRUE, align_ip = TRUE, reference_sample_idx = 2)
+  ds$realize()
+
+  samples <- lapply(ds$sampleNames, ds$getSample)
+  for (s in samples) {
+    expect_false(anyNA(intensity(s)))
+  }
+  rt_lists <- lapply(samples, rtime)
+  expect_true(all(vapply(rt_lists[-1], identical, logical(1), rt_lists[[1]])))
+})
+
+test_that("align() with align_dt = FALSE, align_ip = FALSE skips prealign without crashing", {
+  ds <- make_dataset()
+  dt_before <- dtime(ds$getSample(1))
+
+  align(ds, method_rt = "ptw", align_dt = FALSE, align_ip = FALSE)
+  ds$realize()
+
+  expect_identical(dtime(ds$getSample(1)), dt_before)
+  expect_true(all(ds$align$dt_kcorr == 1))
+})
+
+test_that("align(method_rt = 'pow') on a GCIMSDataset fails fast with a clear message", {
+  skip_if(requireNamespace("pow", quietly = TRUE), "pow is installed; not testing the missing-dependency guard")
+
+  ds <- make_dataset()
+
+  expect_error(
+    align(ds, method_rt = "pow"),
+    "pow.*is not on CRAN/Bioconductor"
+  )
+})


### PR DESCRIPTION
## Summary
- `align-GCIMSDataset.R` (the dataset-level alignment orchestration) had 0% test coverage.
- While building a multi-sample synthetic dataset to test it, found that `align(dataset, align_dt = FALSE, align_ip = FALSE, method_rt = "ptw")` — a documented, legitimate parameter combination — crashed with a confusing `purrr::map_dbl()` "Result must be length 1, not 0" error instead of working.
  - Root cause: skipping `align_dt`/`align_ip` skips the `prealign()` delayed op entirely, so no sample ever gets `proc_params$align$dt_kcorr` set. The later retention-time-warp step then tries to collect `dt_kcorr` from every sample and gets `NULL` instead of a number.
  - Fix: `.align_fun_extract()` now defaults `dt_kcorr` to `1` (i.e. "no drift-time correction was applied") when it was never recorded, matching the semantics `prealign()` itself already uses for its own `align_dt = FALSE` branch.
- Adds `tests/testthat/test-align-GCIMSDataset.R`, covering:
  - the default pipeline (`align_dt`/`align_ip`/`ptw`) producing consistent, NA-free axes across all samples in the dataset
  - an explicit `reference_sample_idx`
  - the `align_dt = FALSE, align_ip = FALSE` regression case above
  - `align(method_rt = "pow")` failing fast with a clear message when `pow` isn't installed
- `align-GCIMSDataset.R` coverage: 0% → 47% (the rest is `alignPlots()`, a plotting helper, plus a few lines inside the `BiocParallel`-executed aggregation helpers that `covr` can't track across worker processes despite being exercised by these tests). Package-wide coverage: 35.9% → 37.9%.

## Test plan
- [x] `testthat::test_local(".")` — full existing suite passes, including the new file (13 assertions)
- [x] `covr::package_coverage()` confirms `align-GCIMSDataset.R` at 47% and no regressions elsewhere
- [x] Manually reproduced the `dt_kcorr` crash before the fix and confirmed it's resolved after


---
_Generated by [Claude Code](https://claude.ai/code/session_019V3CHRGSzcEu3k6tpUFv56)_