### PR TITLE
Add unit tests for utils-integration.R; fix rip-saturation axis bug

### DIFF
--- a/R/utils-integration.R
+++ b/R/utils-integration.R
@@ -2,7 +2,7 @@ find_regions_rip_saturated <- function(aux, rip_saturation_threshold, verbose = 
   the_rip <- find_rip(aux, verbose = verbose, retention_time = retention_time, drift_time = drift_time)
   # Search saturation regions
   rip_region <- aux[the_rip$dt_idx_start:the_rip$dt_idx_end, , drop = FALSE]
-  rip_chrom <- rowSums(rip_region) / nrow(rip_region)
+  rip_chrom <- colSums(rip_region) / nrow(rip_region)
   rt_rip_saturated_indices <- which(rip_chrom <= rip_saturation_threshold * max(rip_chrom))
   if (length(rt_rip_saturated_indices) == 0L) {
     rt_saturated_regions <- matrix(nrow = 0L, ncol = 2L)

--- a/tests/testthat/test-utils-integration.R
+++ b/tests/testthat/test-utils-integration.R
@@ -1,0 +1,106 @@
+gauss <- function(x, center, height, sd) height * exp(-(x - center)^2 / (2 * sd^2))
+
+test_that("find_half_max_boundaries locates the half-max crossings of a single peak", {
+  x <- c(0, 1, 2, 4, 8, 10, 8, 4, 2, 1, 0)
+
+  out <- find_half_max_boundaries(x)
+
+  expect_equal(out$apex_idx, 6L)
+  expect_equal(out$left_bound_idx, 5L)
+  expect_equal(out$right_bound_idx, 7L)
+  expect_equal(out$half_width_left, 1L)
+  expect_equal(out$half_width_right, 1L)
+  expect_equal(out$fwhm, 2L)
+  expect_equal(out$fwhm_sym, 2)
+})
+
+test_that("find_half_max_boundaries returns NaN fwhm_sym for a flat vector with no real peak", {
+  out <- find_half_max_boundaries(rep(5, 50))
+
+  expect_true(is.na(out$fwhm_sym))
+})
+
+test_that("find_rip locates an isolated RIP peak and clips its boundaries to the FWHM rule", {
+  dt_idx <- 1:200
+  tis_shape <- gauss(dt_idx, center = 100, height = 1000, sd = 10)
+  int_mat <- matrix(0, nrow = 200, ncol = 20)
+  rt_apex_col <- 12
+  for (j in 1:20) {
+    int_mat[, j] <- tis_shape * if (j == rt_apex_col) 1 else 0.6
+  }
+
+  out <- find_rip(int_mat)
+
+  # No internal valleys exist in an isolated Gaussian, so the boundaries come
+  # from clipping at the apex +/- 3*fwhm_sym of the TIS profile itself:
+  fwhm_sym <- find_half_max_boundaries(rowSums(int_mat))$fwhm_sym
+  expect_equal(out$dt_idx_apex, 100L)
+  expect_equal(out$rt_idx_apex, rt_apex_col)
+  expect_equal(out$dt_idx_start, 100 - 3 * fwhm_sym)
+  expect_equal(out$dt_idx_end, 100 + 3 * fwhm_sym)
+  expect_equal(length(out$rip), out$dt_idx_end - out$dt_idx_start + 1)
+})
+
+test_that("find_rip prefers a nearby valley over the FWHM clip when the valley is tighter", {
+  dt_idx <- 1:200
+  # Two small satellite peaks close enough to the main RIP to create real
+  # valleys well inside the +/- 3*fwhm_sym clip radius:
+  tis_shape <- gauss(dt_idx, center = 100, height = 1000, sd = 10) +
+    gauss(dt_idx, center = 130, height = 200, sd = 5) +
+    gauss(dt_idx, center = 65, height = 150, sd = 5)
+  int_mat <- matrix(tis_shape, nrow = 200, ncol = 5)
+
+  out <- find_rip(int_mat)
+
+  expect_equal(out$dt_idx_apex, 100L)
+  expect_equal(out$dt_idx_start, 74)
+  expect_equal(out$dt_idx_end, 122)
+})
+
+test_that("find_rip aborts with a clear message when the RIP width can't be located", {
+  int_mat_flat <- matrix(5, nrow = 50, ncol = 10)
+
+  expect_error(
+    suppressWarnings(find_rip(int_mat_flat)),
+    "could not locate the RIP width"
+  )
+})
+
+test_that("find_rip with verbose = TRUE reports the RIP position in physical units", {
+  dt_idx <- 1:200
+  tis_shape <- gauss(dt_idx, center = 100, height = 1000, sd = 10)
+  int_mat <- matrix(tis_shape, nrow = 200, ncol = 5)
+  dt <- dt_idx * 0.1
+  rt <- seq_len(5)
+
+  expect_message(
+    find_rip(int_mat, verbose = TRUE, retention_time = rt, drift_time = dt),
+    "RIP was detected"
+  )
+})
+
+test_that("find_regions_rip_saturated flags retention-time regions where the RIP is depleted", {
+  dt_idx <- 1:200
+  tis_shape <- gauss(dt_idx, center = 100, height = 1000, sd = 10)
+  int_mat <- matrix(0, nrow = 200, ncol = 20)
+  for (j in 1:20) int_mat[, j] <- tis_shape
+  int_mat[, 8:10] <- int_mat[, 8:10] * 0.05 # a saturated/depleted RIP window
+
+  rt <- seq(0, by = 1, length.out = 20)
+  out <- find_regions_rip_saturated(int_mat, rip_saturation_threshold = 0.1, retention_time = rt)
+
+  expect_equal(dim(out), c(1L, 2L))
+  expect_equal(unname(out[1, ]), c(rt[8], rt[10]))
+})
+
+test_that("find_regions_rip_saturated returns an empty matrix when nothing is saturated", {
+  dt_idx <- 1:200
+  tis_shape <- gauss(dt_idx, center = 100, height = 1000, sd = 10)
+  int_mat <- matrix(0, nrow = 200, ncol = 20)
+  for (j in 1:20) int_mat[, j] <- tis_shape
+
+  rt <- seq(0, by = 1, length.out = 20)
+  out <- find_regions_rip_saturated(int_mat, rip_saturation_threshold = 0.1, retention_time = rt)
+
+  expect_equal(nrow(out), 0L)
+})


### PR DESCRIPTION
## Summary
- `utils-integration.R` (RIP detection and peak-integration helpers) had 0% test coverage.
- While building test fixtures for `find_regions_rip_saturated()`, found that it computed:
  ```r
  rip_chrom <- rowSums(rip_region) / nrow(rip_region)
  ```
  `rowSums()` collapses across retention-time columns, producing one value per drift-time row — but the function then treats the resulting indices as retention-time positions (`retention_time[rt_saturated_regions[, 1L]]`), and its only caller, `integratePeaks(GCIMSSample)`, documents and uses the result as a retention-time-indexed saturation window (compared against each peak's `rt_cm_s`). That only works with one value per retention-time column, i.e. `colSums()`, not `rowSums()`. Fixed by swapping `rowSums()` for `colSums()`.
  - **Impact / severity**: this is a bugfix to the `Saturation` column computed by `integratePeaks()`, which flags peaks whose retention-time window overlaps a RIP-depleted region as a QC signal ("more likely that the ROI suffers from non-linearities"). It does **not** affect `Area`, `Volume`, `Asymmetry`, peak clustering, or any other quantification result. I also checked and `Saturation` is currently **not consumed anywhere downstream** in the package — `peakTable()` doesn't read, filter, or aggregate it, and no plotting/reporting code touches it either — so today this column is a QC diagnostic that isn't surfaced past the per-sample peak list unless a user manually inspects `peaks(dataset)`. The fix is still correct and worth having, but the practical blast radius before this PR was a broken-but-unused diagnostic column, not a wrong quantification result.
- Adds `tests/testthat/test-utils-integration.R`, covering:
  - `find_half_max_boundaries()`: exact half-max crossings on a known peak, and the NaN-`fwhm_sym` case for a flat vector
  - `find_rip()`: the FWHM-clip path for an isolated RIP peak, the valley-preferred path when real TIS valleys sit inside the clip radius, the verbose message, and the "could not locate the RIP width" abort on a degenerate/flat matrix
  - `find_regions_rip_saturated()`: a saturated retention-time window correctly reported in retention-time units (regression test for the bug above), and the empty-matrix case when nothing is saturated
- `utils-integration.R` coverage: 0% → 93%. Package-wide coverage: 45.0% → 47.8%.

## Test plan
- [x] `testthat::test_local(".")` — full existing suite passes, including the new file (21 assertions)
- [x] `covr::package_coverage()` confirms `utils-integration.R` at 93% and no regressions elsewhere


---
_Generated by [Claude Code](https://claude.ai/code/session_019V3CHRGSzcEu3k6tpUFv56)_