### PR TITLE
Add unit tests for peakTable.R and integratePeaks-*; fix silent list-col bug

### DIFF
--- a/R/peakTable.R
+++ b/R/peakTable.R
@@ -50,7 +50,7 @@ peakTable <- function(peak_list_clustered, aggregate_conflicting_peaks = NULL) {
   }
 
   peak_list_clustered <- peak_list_clustered |>
-    dplyr::filter(!is.na("cluster"))
+    dplyr::filter(!is.na(.data$cluster))
 
   peak_table_duplicity <- peak_list_clustered |>
     dplyr::select(dplyr::all_of(c("SampleID", "cluster", "Volume"))) |>
@@ -59,6 +59,18 @@ peakTable <- function(peak_list_clustered, aggregate_conflicting_peaks = NULL) {
       values_from = dplyr::all_of("Volume"),
       values_fn = length
     )
+
+  if (is.null(aggregate_conflicting_peaks)) {
+    duplicity_values <- as.matrix(peak_table_duplicity[, -1, drop = FALSE])
+    if (any(duplicity_values > 1L, na.rm = TRUE)) {
+      cli_abort(
+        c(
+          "Some samples have more than one peak assigned to the same cluster",
+          "i" = "Pass a function (e.g. {.code aggregate_conflicting_peaks = max}) to summarize them, or fix the clustering upstream."
+        )
+      )
+    }
+  }
 
   peak_table <- peak_list_clustered |>
     dplyr::select(dplyr::all_of(c("SampleID", "cluster", "Volume"))) |>

--- a/tests/testthat/test-integratePeaks-GCIMSDataset.R
+++ b/tests/testthat/test-integratePeaks-GCIMSDataset.R
@@ -1,0 +1,31 @@
+test_that("integratePeaks on a GCIMSDataset integrates each sample and combines them with a UniqueID", {
+  dt <- seq(0, 4, by = 0.02)
+  rt <- seq(0, 100, by = 0.5)
+  make_sample <- function() {
+    int_mat <- matrix(0.1, nrow = length(dt), ncol = length(rt))
+    int_mat[150:160, 40:50] <- int_mat[150:160, 40:50] + 50
+    GCIMSSample(drift_time = dt, retention_time = rt, data = int_mat)
+  }
+  ds <- GCIMSDataset$new_from_list(
+    samples = list(s1 = make_sample(), s2 = make_sample()),
+    on_ram = TRUE, scratch_dir = NULL
+  )
+
+  peak_list <- data.frame(
+    SampleID = c("s1", "s2"),
+    PeakID = c("1", "1"),
+    dt_min_ms = dt[150], dt_max_ms = dt[160],
+    rt_min_s = rt[40], rt_max_s = rt[50],
+    rt_apex_s = rt[45], rt_cm_s = rt[45],
+    fixedsize_dt_min_ms = dt[148], fixedsize_dt_max_ms = dt[162],
+    fixedsize_rt_min_s = rt[38], fixedsize_rt_max_s = rt[52]
+  )
+
+  integratePeaks(ds, peak_list, integration_size_method = "free_size")
+  ds$realize()
+  pl <- peaks(ds)
+
+  expect_equal(nrow(pl), 2L)
+  expect_equal(sort(pl$UniqueID), c("s1/1", "s2/1"))
+  expect_equal(pl$Volume[pl$SampleID == "s1"], pl$Volume[pl$SampleID == "s2"])
+})

--- a/tests/testthat/test-integratePeaks-GCIMSSample.R
+++ b/tests/testthat/test-integratePeaks-GCIMSSample.R
@@ -1,0 +1,113 @@
+gauss <- function(x, center, height, sd) height * exp(-(x - center)^2 / (2 * sd^2))
+
+dt_axis <- seq(0, 4, by = 0.02) # 201 points
+rt_axis <- seq(0, 100, by = 0.5) # 201 points
+
+# A sample with a RIP row (dominant TIS row, near the low end of drift time)
+# that's depleted/"saturated" over retention-time indices 90-100, plus two
+# constant-intensity peak blocks elsewhere in drift time: one inside a
+# non-saturated retention-time window, one inside the saturated window.
+make_integration_sample <- function() {
+  int_mat <- matrix(0.1, nrow = length(dt_axis), ncol = length(rt_axis))
+  rip_profile <- gauss(seq_along(dt_axis), center = 20, height = 1000, sd = 5)
+  for (j in seq_along(rt_axis)) {
+    scale_j <- if (j >= 90 && j <= 100) 0.02 else 1
+    int_mat[, j] <- int_mat[, j] + rip_profile * scale_j
+  }
+  int_mat[150:160, 40:50] <- int_mat[150:160, 40:50] + 50 # peak A: non-saturated window
+  int_mat[150:160, 92:98] <- int_mat[150:160, 92:98] + 50 # peak B: saturated window
+  s <- GCIMSSample(drift_time = dt_axis, retention_time = rt_axis, data = int_mat)
+  description(s) <- "S1"
+  s
+}
+
+make_peak_list <- function() {
+  data.frame(
+    SampleID = c("S1", "S1"),
+    dt_min_ms = dt_axis[150], dt_max_ms = dt_axis[160],
+    rt_min_s = c(rt_axis[40], rt_axis[92]),
+    rt_max_s = c(rt_axis[50], rt_axis[98]),
+    rt_apex_s = c(rt_axis[45], rt_axis[95]),
+    rt_cm_s = c(rt_axis[45], rt_axis[95]),
+    fixedsize_dt_min_ms = dt_axis[148], fixedsize_dt_max_ms = dt_axis[162],
+    fixedsize_rt_min_s = c(rt_axis[38], rt_axis[90]),
+    fixedsize_rt_max_s = c(rt_axis[52], rt_axis[100])
+  )
+}
+
+test_that("integratePeaks computes Area from the ROI's physical dimensions", {
+  s <- make_integration_sample()
+  peak_list <- make_peak_list()
+
+  out <- integratePeaks(s, peak_list, integration_size_method = "free_size")
+  pl <- peaks(out)
+
+  expected_area <- (dt_axis[160] - dt_axis[150]) * (rt_axis[50] - rt_axis[40])
+  expect_equal(pl$Area[1], expected_area)
+})
+
+test_that("integratePeaks computes Volume as the sum of intensities in the ROI", {
+  s <- make_integration_sample()
+  peak_list <- make_peak_list()
+
+  out <- integratePeaks(s, peak_list, integration_size_method = "free_size")
+  pl <- peaks(out)
+
+  patch <- intensity(s, dt_range = c(dt_axis[150], dt_axis[160]), rt_range = c(rt_axis[40], rt_axis[50]))
+  expected_volume <- sum(patch) * (rt_axis[2] - rt_axis[1]) * (dt_axis[2] - dt_axis[1])
+  expect_equal(pl$Volume[1], expected_volume)
+})
+
+test_that("integratePeaks with fixed_size uses the wider fixedsize_* bounds instead of the ROI's own bounds", {
+  s <- make_integration_sample()
+  peak_list <- make_peak_list()
+
+  out_free <- integratePeaks(s, peak_list, integration_size_method = "free_size")
+  out_fixed <- integratePeaks(s, peak_list, integration_size_method = "fixed_size")
+
+  expect_gt(peaks(out_fixed)$Volume[1], peaks(out_free)$Volume[1])
+})
+
+test_that("integratePeaks computes a symmetric Asymmetry of 0 for a centered apex", {
+  s <- make_integration_sample()
+  peak_list <- make_peak_list()
+  peak_list$rt_apex_s[1] <- (rt_axis[40] + rt_axis[50]) / 2 # dead center
+
+  out <- integratePeaks(s, peak_list, integration_size_method = "free_size")
+
+  expect_equal(peaks(out)$Asymmetry[1], 0)
+})
+
+test_that("integratePeaks computes a nonzero Asymmetry for an off-center apex", {
+  s <- make_integration_sample()
+  peak_list <- make_peak_list()
+  peak_list$rt_apex_s[1] <- rt_axis[43]
+
+  out <- integratePeaks(s, peak_list, integration_size_method = "free_size")
+
+  rising <- rt_axis[43] - rt_axis[40]
+  falling <- rt_axis[50] - rt_axis[43]
+  expect_equal(peaks(out)$Asymmetry[1], round(falling / rising - 1, 2))
+})
+
+test_that("integratePeaks flags Saturation only for peaks inside a RIP-depleted retention-time window", {
+  s <- make_integration_sample()
+  peak_list <- make_peak_list()
+
+  out <- integratePeaks(s, peak_list, integration_size_method = "free_size", rip_saturation_threshold = 0.1)
+  pl <- peaks(out)
+
+  expect_false(pl$Saturation[1]) # non-saturated window
+  expect_true(pl$Saturation[2]) # saturated window
+})
+
+test_that("integratePeaks only integrates peaks belonging to the given sample", {
+  s <- make_integration_sample()
+  peak_list <- make_peak_list()
+  peak_list$SampleID[2] <- "SomeOtherSample"
+
+  out <- integratePeaks(s, peak_list, integration_size_method = "free_size")
+
+  expect_equal(nrow(peaks(out)), 1L)
+  expect_equal(peaks(out)$SampleID, "S1")
+})

--- a/tests/testthat/test-peakTable.R
+++ b/tests/testthat/test-peakTable.R
@@ -1,0 +1,91 @@
+test_that("peakTable pivots a clustered peak list into a sample x cluster matrix", {
+  pl <- data.frame(
+    SampleID = c("S1", "S1", "S2", "S2"),
+    cluster = c("Cluster1", "Cluster2", "Cluster1", "Cluster2"),
+    Volume = c(10, 20, 8, 18)
+  )
+
+  out <- peakTable(pl)
+
+  expect_equal(
+    out$peak_table_matrix,
+    matrix(
+      c(10, 8, 20, 18),
+      nrow = 2, ncol = 2,
+      dimnames = list(c("S1", "S2"), c("Cluster1", "Cluster2"))
+    )
+  )
+})
+
+test_that("peakTable excludes peaks that were never assigned to a cluster", {
+  pl <- data.frame(
+    SampleID = c("S1", "S1", "S2"),
+    cluster = c("Cluster1", NA, "Cluster1"),
+    Volume = c(10, 99, 8)
+  )
+
+  out <- peakTable(pl)
+
+  expect_equal(colnames(out$peak_table_matrix), "Cluster1")
+  expect_equal(unname(out$peak_table_matrix[, "Cluster1"]), c(10, 8))
+})
+
+test_that("peakTable requires a Volume column", {
+  expect_error(
+    peakTable(data.frame(SampleID = "S1", cluster = "C1")),
+    "Volume"
+  )
+})
+
+test_that("peakTable errors when two peaks from the same sample land in the same cluster and no aggregate function is given", {
+  pl <- data.frame(SampleID = c("S1", "S1"), cluster = c("C1", "C1"), Volume = c(5, 7))
+
+  expect_error(
+    peakTable(pl),
+    "more than one peak assigned to the same cluster"
+  )
+})
+
+test_that("peakTable resolves conflicting peaks with aggregate_conflicting_peaks", {
+  pl <- data.frame(SampleID = c("S1", "S1"), cluster = c("C1", "C1"), Volume = c(5, 7))
+
+  out <- peakTable(pl, aggregate_conflicting_peaks = max)
+
+  expect_equal(unname(out$peak_table_matrix[, "C1"]), 7)
+  expect_equal(out$peak_table_duplicity$S1, 2L)
+})
+
+test_that("omit_times drops ROIs at the given drift times", {
+  peak_list <- data.frame(
+    rt_apex_s = c(1, 2, 3, 3, 4, 4, 5, 5, 6, 6),
+    dt_apex_ms = c(2, 4, 6, 4, 8, 4, 10, 4, 4, 12)
+  )
+
+  out <- omit_times(peak_list, dt_time_2_omit = 4)
+
+  expect_equal(nrow(out), 5L)
+  expect_false(any(out$dt_apex_ms == 4))
+})
+
+test_that("omit_times drops ROIs at the given retention times", {
+  peak_list <- data.frame(
+    rt_apex_s = c(1, 2, 3, 3, 4, 4, 5, 5, 6, 6),
+    dt_apex_ms = c(2, 4, 6, 4, 8, 4, 10, 4, 4, 12)
+  )
+
+  out <- omit_times(peak_list, rt_time_2_omit = c(3, 5))
+
+  expect_equal(nrow(out), 6L)
+  expect_false(any(out$rt_apex_s %in% c(3, 5)))
+})
+
+test_that("omit_times with no times to omit returns the peak list unchanged", {
+  peak_list <- data.frame(
+    rt_apex_s = c(1, 2, 3),
+    dt_apex_ms = c(2, 4, 6)
+  )
+
+  out <- omit_times(peak_list)
+
+  expect_equal(out, peak_list)
+})


### PR DESCRIPTION
## Summary
- `peakTable.R` and `integratePeaks-GCIMSSample.R`/`integratePeaks-GCIMSDataset.R` had 0% test coverage.
- While building test fixtures, found that `peakTable()` didn't honor its own documented contract for conflicting peaks: *"aggregate_conflicting_peaks: NULL or a function. [...] If NULL, throw an error."* In practice, when two peaks from the same sample land in the same cluster and `aggregate_conflicting_peaks` is `NULL` (the default), `tidyr::pivot_wider()` only emits a warning and silently produces list-columns (each cell a `numeric(2)` instead of a single number). `peak_table_matrix` — documented as "the peak table [...] in matrix form" — ends up being an R `matrix` whose cells are actually lists, not numbers, which would break or silently misbehave in any downstream numeric code (`imputePeakTable()`, PCA, modeling). Fixed by explicitly checking `peak_table_duplicity` for any count > 1 and aborting with a clear message before the problematic pivot, matching the documented behavior.
- Also fixed a smaller issue found on the way: `dplyr::filter(!is.na("cluster"))` quoted `"cluster"` as a literal string, making the filter a no-op, so peaks with `cluster = NA` (unclustered peaks) were never excluded and would leak into the peak table as a spurious NA-cluster row. Changed to `!is.na(.data$cluster)`.
- Adds:
  - `tests/testthat/test-peakTable.R`: basic pivoting, the NA-cluster exclusion fix, the new conflicting-peaks error, and `aggregate_conflicting_peaks` resolving it; plus `omit_times()`
  - `tests/testthat/test-integratePeaks-GCIMSSample.R`: Area, Volume (`free_size` vs `fixed_size`), Asymmetry (centered and off-center apex), Saturation flagging end-to-end (using the `utils-integration.R` fix from #34), and per-sample filtering
  - `tests/testthat/test-integratePeaks-GCIMSDataset.R`: the dataset-level delayed-op dispatch producing a combined peak list with `UniqueID`
- Coverage: `peakTable.R` 0% → 100%, `integratePeaks-GCIMSSample.R` 0% → 98%, `integratePeaks-GCIMSDataset.R` 0% → 100%. Package-wide: 47.8% → 51.0% (crossing 50% for the first time).

## Test plan
- [x] `testthat::test_local(".")` — full existing suite passes, including the three new files (24 assertions)
- [x] `covr::package_coverage()` confirms the coverage numbers above and no regressions elsewhere


---
_Generated by [Claude Code](https://claude.ai/code/session_019V3CHRGSzcEu3k6tpUFv56)_