### PR TITLE
Add unit tests for aaa-class-GCIMSDataset.R; fix sampleNames<- crash

### DIFF
--- a/R/aaa-class-GCIMSDataset.R
+++ b/R/aaa-class-GCIMSDataset.R
@@ -403,7 +403,7 @@ GCIMSDataset <- R6::R6Class("GCIMSDataset",
       # Update pData accordingly
       self$pData$SampleID <- value
       # And the sample descriptions:
-      self$updateSampleDescriptions(value)
+      private$updateSampleDescriptions(value)
       self
     }
   ),
@@ -542,6 +542,7 @@ validate_pData <- function(pData) {
   if (length(sampleid_col) > 1) {
     errors <- c(errors, "pData should only have one SampleID column (don't use sampleid or other casing)")
   }
+  abort_if_errors(errors, title = "pData is not valid")
 
   # SampleID should be a character column. If it is integer we warn.
   sampleids <- pData[[sampleid_col]]
@@ -618,9 +619,9 @@ validate_pData_samples <- function(pData, samples) {
       errors <- c(
         errors,
         "Samples given as a list, but are missing in pData.",
-        "x" = "Samples for {length(missing_samples)} SampleIDs were not found",
+        "x" = glue::glue("Samples for {length(missing_samples)} SampleIDs were not found"),
         "i" = "Either remove them from pData or provide the samples",
-        "i" = "For instance: {head(sampleids[missing_samples])}"
+        "i" = glue::glue("For instance: {paste(head(pData[['SampleID']][missing_samples]), collapse = ', ')}")
       )
     }
   }
@@ -759,7 +760,7 @@ read_sample <- function(filename, base_dir, parser = "default") {
     } else {
       cli_abort(
         message = c(
-          "Support for reading {.path filename} not yet implemented",
+          "Support for reading {.path {filename}} not yet implemented",
           "i" = "Please use a custom {.code parser}.",
           "i" = "Checkout the vignette at {.url https://sipss.github.io/GCIMS/articles/importing-custom-data-formats.html}"
         )

--- a/tests/testthat/test-aaa-class-GCIMSDataset-validators.R
+++ b/tests/testthat/test-aaa-class-GCIMSDataset-validators.R
@@ -1,0 +1,160 @@
+make_sample <- function() GCIMSSample(1:2, 1:2, matrix(1, nrow = 2, ncol = 2))
+
+test_that("validate_on_ram accepts TRUE/FALSE-like values and rejects the rest", {
+  expect_true(validate_on_ram(TRUE))
+  expect_false(validate_on_ram(FALSE))
+  expect_true(validate_on_ram(1))
+
+  expect_error(validate_on_ram(c(TRUE, FALSE)), "on_ram must be either TRUE or FALSE")
+  expect_error(validate_on_ram(NA), "on_ram must be either TRUE or FALSE")
+})
+
+test_that("validate_keep_intermediate requires a single logical", {
+  expect_true(validate_keep_intermediate(TRUE))
+  expect_error(validate_keep_intermediate("yes"), "must be either TRUE or FALSE")
+})
+
+test_that("validate_parser accepts 'default' or a function", {
+  expect_equal(validate_parser("default"), "default")
+  f <- function(x) x
+  expect_identical(validate_parser(f), f)
+  expect_error(validate_parser("bogus"), "must be either 'default' or a function")
+})
+
+test_that("validate_samples accepts NULL and a named list of GCIMSSample objects", {
+  expect_null(validate_samples(NULL))
+
+  s <- make_sample()
+  out <- validate_samples(list(a = s))
+  expect_named(out, "a")
+})
+
+test_that("validate_samples rejects a non-list", {
+  expect_error(validate_samples(1:3), "named list of GCIMSSample")
+})
+
+test_that("validate_samples auto-names an unnamed list with a warning", {
+  s <- make_sample()
+  expect_warning(
+    out <- validate_samples(list(s)),
+    "Using Sample1"
+  )
+  expect_named(out, "Sample1")
+})
+
+test_that("validate_samples rejects duplicated or empty names, and non-GCIMSSample elements", {
+  s <- make_sample()
+  expect_error(validate_samples(list(a = s, a = s)), "should be unique")
+  expect_error(validate_samples(list(a = 1)), "not of type `GCIMSSample`")
+})
+
+test_that("validate_pData requires a SampleID column and errors with a clear message otherwise", {
+  expect_error(
+    validate_pData(data.frame(Foo = 1)),
+    "should have a SampleID column"
+  )
+})
+
+test_that("validate_pData normalizes SampleID/FileName columns and coerces integer IDs", {
+  pd <- validate_pData(data.frame(SampleID = c("s1", "s2"), Extra = "x"))
+  expect_equal(colnames(pd)[1:2], c("SampleID", "FileName"))
+  expect_equal(as.character(pd$SampleID), c("s1", "s2"))
+
+  expect_warning(
+    pd2 <- validate_pData(data.frame(SampleID = 1:2)),
+    "coerced to a character column"
+  )
+  expect_equal(as.character(pd2$SampleID), c("1", "2"))
+})
+
+test_that("validate_pData_samples defaults to an empty pData/samples pair when both are NULL", {
+  out <- validate_pData_samples(NULL, NULL)
+  expect_equal(nrow(out$pData), 0L)
+  expect_equal(length(out$samples), 0L)
+})
+
+test_that("validate_pData_samples builds pData from sample names when pData is NULL", {
+  s <- make_sample()
+  out <- validate_pData_samples(NULL, list(a = s))
+  expect_equal(as.character(out$pData$SampleID), "a")
+})
+
+test_that("validate_pData_samples errors with a readable message when samples are missing from pData", {
+  s <- make_sample()
+  expect_error(
+    suppressWarnings(validate_pData_samples(data.frame(SampleID = "b"), list(a = s))),
+    "missing in pData"
+  )
+})
+
+test_that("check_files errors listing missing files", {
+  expect_error(
+    check_files("does_not_exist.mea", tempdir()),
+    "does_not_exist.mea"
+  )
+})
+
+test_that("check_files passes silently when all files exist", {
+  f <- tempfile(fileext = ".mea")
+  file.create(f)
+  on.exit(unlink(f))
+
+  expect_no_error(check_files(basename(f), dirname(f)))
+})
+
+test_that("abort_if_errors aborts only when there are errors", {
+  expect_error(abort_if_errors("bad thing", title = "Oops"), "Oops")
+  expect_no_error(abort_if_errors(character(0)))
+})
+
+test_that("validate_base_dir requires an existing directory and normalizes the path", {
+  out <- validate_base_dir(tempdir())
+  expect_true(dir.exists(out))
+  expect_error(validate_base_dir("/does/not/exist/xyz123"), "does not exist")
+})
+
+test_that("validate_scratch_dir creates a temporary directory when NULL", {
+  out <- validate_scratch_dir(NULL)
+  expect_true(dir.exists(out))
+})
+
+test_that("optimize_RIC_TIS moves extract_dtime_rtime/extract_RIC_and_TIS operations to the end", {
+  op1 <- DelayedOperation(name = "smooth", fun = function(x) x)
+  op2 <- DelayedOperation(name = "extract_dtime_rtime", fun_extract = function(x) x)
+  op3 <- DelayedOperation(name = "detectPeaks", fun = function(x) x)
+  op4 <- DelayedOperation(name = "extract_RIC_and_TIS", fun_extract = function(x) x)
+
+  out <- optimize_RIC_TIS(list(op1, op2, op3, op4))
+
+  expect_equal(purrr::map_chr(out, name), c("smooth", "detectPeaks", "extract_dtime_rtime", "extract_RIC_and_TIS"))
+})
+
+test_that("optimize_RIC_TIS is a no-op when neither extraction operation is queued", {
+  op1 <- DelayedOperation(name = "smooth", fun = function(x) x)
+  op3 <- DelayedOperation(name = "detectPeaks", fun = function(x) x)
+
+  out <- optimize_RIC_TIS(list(op1, op3))
+
+  expect_identical(purrr::map_chr(out, name), c("smooth", "detectPeaks"))
+})
+
+test_that("read_sample dispatches .mea/.mea.gz to read_mea and reads a real sample", {
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+
+  out <- read_sample(basename(sample_file), base_dir = dirname(sample_file))
+
+  expect_s4_class(out, "GCIMSSample")
+})
+
+test_that("read_sample errors on an unsupported extension, naming the actual file", {
+  expect_error(
+    read_sample("foo.xyz", base_dir = "/some/dir"),
+    "/some/dir/foo.xyz"
+  )
+})
+
+test_that("read_sample dispatches to a custom parser function when given one", {
+  out <- read_sample("whatever.xyz", base_dir = tempdir(), parser = function(filename) list(custom = filename))
+
+  expect_named(out, "custom")
+})

--- a/tests/testthat/test-aaa-class-GCIMSDataset.R
+++ b/tests/testthat/test-aaa-class-GCIMSDataset.R
@@ -1,0 +1,105 @@
+make_ram_dataset <- function() {
+  s1 <- GCIMSSample(1:2, 1:2, matrix(1, nrow = 2, ncol = 2))
+  s2 <- GCIMSSample(1:2, 1:2, matrix(2, nrow = 2, ncol = 2))
+  GCIMSDataset$new_from_list(samples = list(a = s1, b = s2), on_ram = TRUE, scratch_dir = NULL)
+}
+
+test_that("GCIMSDataset can be constructed from files on disk", {
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  pData <- data.frame(SampleID = "s1", FileName = basename(sample_file))
+
+  ds <- GCIMSDataset$new(pData = pData, base_dir = dirname(sample_file), on_ram = TRUE)
+
+  expect_equal(ds$sampleNames, "s1")
+  expect_s4_class(ds$getSample(1), "GCIMSSample")
+})
+
+test_that("GCIMSDataset construction from files errors clearly when a file is missing", {
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  pData <- data.frame(SampleID = "s1", FileName = "does_not_exist.mea")
+
+  expect_error(
+    GCIMSDataset$new(pData = pData, base_dir = dirname(sample_file), on_ram = TRUE),
+    "does_not_exist.mea"
+  )
+})
+
+test_that("dataset$sampleNames<- renames samples, updates pData, and validates its input", {
+  ds <- make_ram_dataset()
+
+  ds$sampleNames <- c("x", "y")
+
+  expect_equal(ds$sampleNames, c("x", "y"))
+  expect_equal(as.character(ds$pData$SampleID), c("x", "y"))
+
+  expect_error(
+    {
+      ds$sampleNames <- "only_one"
+    },
+    "number of sample names"
+  )
+  expect_error(
+    {
+      ds$sampleNames <- c("z", "z")
+    },
+    "unique and not missing"
+  )
+})
+
+test_that("is_on_disk distinguishes RAM datasets from disk datasets", {
+  ds <- make_ram_dataset()
+  expect_false(ds$is_on_disk())
+})
+
+test_that("copy() on a RAM dataset returns an independent GCIMSDataset with the same content", {
+  ds <- make_ram_dataset()
+
+  ds2 <- ds$copy()
+
+  expect_false(identical(ds, ds2))
+  expect_s3_class(ds2, "GCIMSDataset")
+  expect_equal(ds2$sampleNames, ds$sampleNames)
+})
+
+test_that("updateScratchDir() and getCurrentDir() warn and no-op on a RAM dataset", {
+  ds <- make_ram_dataset()
+
+  expect_warning(ds$updateScratchDir(tempdir()), "has no effect")
+  expect_warning(result <- ds$getCurrentDir(), "only makes sense for on-disk datasets")
+  expect_null(result)
+})
+
+test_that("print() describes the dataset without erroring", {
+  ds <- make_ram_dataset()
+
+  out <- capture.output(print(ds))
+
+  expect_true(any(grepl("GCIMSDataset", out)))
+  expect_true(any(grepl("Stored on RAM", out)))
+})
+
+test_that("subset(inplace = FALSE) returns a copy, leaving the original dataset untouched", {
+  ds <- make_ram_dataset()
+
+  subset_copy <- ds$subset("a", inplace = FALSE)
+
+  expect_equal(ds$sampleNames, c("a", "b"))
+  expect_equal(subset_copy$sampleNames, "a")
+})
+
+test_that("subset(inplace = TRUE) modifies the dataset itself", {
+  ds <- make_ram_dataset()
+
+  ds$subset("a", inplace = TRUE)
+
+  expect_equal(ds$sampleNames, "a")
+})
+
+test_that("subset() also filters the peaks slot down to the remaining samples", {
+  ds <- make_ram_dataset()
+  ds$peaks <- data.frame(SampleID = c("a", "a", "b"), PeakID = c("1", "2", "1"))
+
+  ds$subset("a", inplace = TRUE)
+
+  expect_equal(ds$peaks$SampleID, c("a", "a"))
+})


### PR DESCRIPTION
and two pData-validation crashes

aaa-class-GCIMSDataset.R (the GCIMSDataset R6 class: construction,
subsetting, copying, and its pData/samples validation helpers) was
only 51% covered. While building test fixtures, found three real bugs:

1. dataset$sampleNames <- new_names always crashed with "attempt to
   apply non-function". The active binding setter called
   self$updateSampleDescriptions(value), but updateSampleDescriptions
   is a *private* method - self$ only sees public members, so it
   resolved to NULL and NULL(value) crashed. The constructor already
   called it correctly via private$; the active binding had the wrong
   scope. Fixed by using private$updateSampleDescriptions(value).
   Verified this predates this session's other changes.

2. validate_pData() crashed with a cryptic
   "attempt to extract less than one element" instead of its intended
   "pData should have a SampleID column" message, when pData was
   missing that column. It accumulated the error but kept using the
   now-invalid (empty) column index before ever checking
   abort_if_errors(). Fixed by aborting immediately after detecting
   the SampleID column problem, before that index is used.

3. validate_pData_samples()'s "samples given as a list but missing in
   pData" error crashed with "object 'missing_samples' not found"
   instead of showing its intended message. The error string embedded
   {} glue placeholders assuming they'd be evaluated where
   missing_samples/sampleids are defined (inside
   validate_pData_samples()), but they're actually evaluated later,
   inside the separate abort_if_errors() helper's own frame - plus
   `sampleids` was never even a defined variable in this function's
   scope. Fixed by pre-interpolating with glue::glue() at the point
   where the variables are in scope, and referencing pData$SampleID
   instead of the undefined `sampleids`.

Also fixed a minor cosmetic issue found along the way: read_sample()'s
unsupported-extension error showed the literal word "filename" instead
of the actual path, because {.path filename} needs nested braces
({.path {filename}}) for cli to interpolate a variable rather than
treat it as literal text.

Adds:
- tests/testthat/test-aaa-class-GCIMSDataset-validators.R: the pure
  validation helpers (validate_on_ram, validate_keep_intermediate,
  validate_parser, validate_samples, validate_pData,
  validate_pData_samples, validate_base_dir, validate_scratch_dir,
  check_files, abort_if_errors), optimize_RIC_TIS() (delayed-op
  reordering), and read_sample() (.mea/.mea.gz via a real sample
  file, unsupported extensions, and custom parsers)
- tests/testthat/test-aaa-class-GCIMSDataset.R: constructing a dataset
  from files on disk (and the missing-file error), the sampleNames<-
  regression above (plus its validation errors), is_on_disk(),
  copy(), updateScratchDir()/getCurrentDir()'s RAM no-op/warning
  branches, print(), and subset() (inplace vs copy, and that it also
  filters the peaks slot)

Coverage: aaa-class-GCIMSDataset.R 51% -> 88%. Package-wide:
59.7% -> 60.3%.