### PR TITLE
Add unit tests for baseline correction (utils-baseline.R and baseline-GCIMSSample.R)

### DIFF
--- a/tests/testthat/test-baseline-GCIMSSample.R
+++ b/tests/testthat/test-baseline-GCIMSSample.R
@@ -1,0 +1,72 @@
+gauss <- function(x, center, height, sd) height * exp(-(x - center)^2 / (2 * sd^2))
+
+make_sample_with_baseline <- function() {
+  dt <- seq(0, 4, by = 0.02) # 201 pts
+  rt <- seq(0, 50, by = 0.5) # 101 pts
+  int_mat <- matrix(50, nrow = length(dt), ncol = length(rt)) + # flat baseline offset
+    outer(gauss(dt, 2, 500, 0.1), gauss(rt, 25, 1, 3)) # a peak
+  GCIMSSample(drift_time = dt, retention_time = rt, data = int_mat)
+}
+
+test_that("baseline() errors before estimateBaseline() has been run", {
+  s <- make_sample_with_baseline()
+
+  expect_error(baseline(s), "estimateBaseline")
+  expect_null(baseline(s, .error_if_missing = FALSE))
+})
+
+test_that("estimateBaseline() with remove = TRUE estimates and subtracts a flat baseline", {
+  s <- make_sample_with_baseline()
+
+  out <- estimateBaseline(s, dt_peak_fwhm_ms = 0.3, dt_region_multiplier = 6, rt_length_s = 10, remove = TRUE)
+  bl <- baseline(out)
+
+  expect_equal(dim(bl), dim(intensity(s)))
+  # Far from the peak, the estimated baseline tracks the known flat offset (50)
+  # and the residual intensity is close to zero:
+  expect_equal(bl[1, 1], 50, tolerance = 5)
+  expect_equal(intensity(out)[1, 1], 0, tolerance = 5)
+  # The peak itself survives baseline removal:
+  dt <- dtime(s)
+  rt <- rtime(s)
+  expect_gt(intensity(out)[which(dt == 2), which(rt == 25)], 400)
+})
+
+test_that("estimateBaseline() with remove = FALSE sets the baseline but leaves the data untouched", {
+  s <- make_sample_with_baseline()
+
+  out <- estimateBaseline(s, dt_peak_fwhm_ms = 0.3, dt_region_multiplier = 6, rt_length_s = 10, remove = FALSE)
+
+  expect_identical(intensity(out), intensity(s))
+  expect_false(is.null(baseline(out, .error_if_missing = FALSE)))
+})
+
+test_that("baseline() subsets by dt_range/rt_range and sets dimnames", {
+  s <- make_sample_with_baseline()
+  out <- estimateBaseline(s, dt_peak_fwhm_ms = 0.3, dt_region_multiplier = 6, rt_length_s = 10)
+
+  bl_sub <- baseline(out, dt_range = c(0, 1), rt_range = c(0, 10))
+
+  expect_equal(dim(bl_sub), c(51L, 21L))
+  expect_named(dimnames(bl_sub), c("dt_ms", "rt_s"))
+})
+
+test_that("baseline<- rejects a value with the wrong dimensions", {
+  s <- make_sample_with_baseline()
+
+  expect_error(
+    {
+      baseline(s) <- matrix(1, 2, 2)
+    },
+    "same length as the intensity"
+  )
+})
+
+test_that("baseline<- accepts a matrix matching the sample's dimensions", {
+  s <- make_sample_with_baseline()
+  bl <- matrix(0, nrow = nrow(intensity(s)), ncol = ncol(intensity(s)))
+
+  baseline(s) <- bl
+
+  expect_equal(baseline(s), bl, ignore_attr = TRUE)
+})

--- a/tests/testthat/test-utils-baseline.R
+++ b/tests/testthat/test-utils-baseline.R
@@ -1,0 +1,65 @@
+gauss <- function(x, center, height, sd) height * exp(-(x - center)^2 / (2 * sd^2))
+
+test_that("compute_baseline connects per-region local minima with linear interpolation", {
+  aux <- matrix(c(5, 1, 8, 6, 2, 9, 7, 0, 3), ncol = 1)
+  x <- seq_len(nrow(aux))
+
+  bl <- compute_baseline(aux, x, number_of_regions = 3, region_size = 3)
+
+  # Region minima are at (x=2, y=1), (x=5, y=2), (x=8, y=0); connected by
+  # linear interpolation (and extrapolated at the edges):
+  expected <- signal::interp1(x = c(2, 5, 8), y = c(1, 2, 0), xi = 1:9, method = "linear", extrap = TRUE)
+  expect_equal(as.numeric(bl), expected)
+})
+
+test_that("compute_baseline handles a shorter last region", {
+  aux <- matrix(c(5, 1, 8, 6, 2), ncol = 1) # 5 points, region_size 3 -> regions [1-3], [4-5]
+
+  bl <- compute_baseline(aux, x = 1:5, number_of_regions = 2, region_size = 3)
+
+  # Region minima at (x=2, y=1) and (x=5, y=2):
+  expected <- signal::interp1(x = c(2, 5), y = c(1, 2), xi = 1:5, method = "linear", extrap = TRUE)
+  expect_equal(as.numeric(bl), expected)
+})
+
+test_that("compute_baseline processes each column independently", {
+  aux <- matrix(c(5, 1, 8, 10, 2, 16, 6, 9, 3, 12, 18, 6), nrow = 6, ncol = 2)
+
+  bl <- compute_baseline(aux, x = 1:6, number_of_regions = 2, region_size = 3)
+
+  # Column 1: region minima at (x=2, y=1) and (x=5, y=2)
+  expect_equal(bl[, 1], signal::interp1(x = c(2, 5), y = c(1, 2), xi = 1:6, method = "linear", extrap = TRUE))
+  # Column 2: region minima at (x=3, y=3) and (x=6, y=6)
+  expect_equal(bl[, 2], signal::interp1(x = c(3, 6), y = c(3, 6), xi = 1:6, method = "linear", extrap = TRUE))
+})
+
+test_that("estimate_baseline_td estimates a baseline close to a known flat offset", {
+  y <- gauss(1:200, 50, 100, 5)
+  aux <- matrix(y + 10, ncol = 1) # a peak riding on a flat baseline of 10
+
+  bl <- estimate_baseline_td(aux, sig_mult = 12, peak_fwhm_pts = 12)
+
+  expect_equal(dim(bl), dim(aux))
+  # Far from the peak, the baseline should track the flat offset:
+  expect_equal(bl[1, 1], 10, tolerance = 1)
+})
+
+test_that("estimate_baseline_td auto-detects peak_fwhm_pts from the RIP position when not given", {
+  y <- gauss(1:200, 50, 100, 5)
+  aux <- matrix(y, ncol = 1)
+
+  bl <- estimate_baseline_td(aux, sig_mult = 12)
+
+  expect_equal(dim(bl), dim(aux))
+  expect_lt(bl[50, 1], 10) # near the peak apex, baseline should stay low
+})
+
+test_that("estimate_baseline_tr applies compute_baseline along the retention-time axis", {
+  aux <- matrix(1:12, nrow = 3, ncol = 4)
+
+  bl <- estimate_baseline_tr(aux, region_size = 2)
+
+  expected <- t(compute_baseline(t(aux), x = seq_len(ncol(aux)), number_of_regions = ceiling(ncol(aux) / 2), region_size = 2))
+  expect_identical(bl, expected)
+  expect_equal(dim(bl), dim(aux))
+})


### PR DESCRIPTION
## Summary
- `utils-baseline.R` and `baseline-GCIMSSample.R` had 0-9% coverage despite implementing a real preprocessing algorithm (connect-local-minima baseline estimation, run before peak detection). No bugs found this round; both are clean.
- Adds:
  - `tests/testthat/test-utils-baseline.R`: `compute_baseline()` with hand-verified region minima and linear interpolation (including a shorter last region, and that columns are processed independently), `estimate_baseline_td()` with both an explicit and an auto-detected (from the RIP position) `peak_fwhm_pts`, and `estimate_baseline_tr()`'s transpose-compute-transpose behavior
  - `tests/testthat/test-baseline-GCIMSSample.R`: `baseline()` erroring (or returning `NULL`) before `estimateBaseline()` has run, `estimateBaseline()`'s `remove = TRUE/FALSE` behavior against a sample with a known flat baseline and a known peak (baseline tracks the flat offset away from the peak, residual intensity drops near zero, the peak itself survives), `baseline()`'s `dt_range`/`rt_range` subsetting, and `baseline<-()`'s dimension validation
- Coverage: `utils-baseline.R` 0% → 100%, `baseline-GCIMSSample.R` 9% → 97%. Package-wide: 65.1% → 66.8%.

## Test plan
- [x] `testthat::test_local(".")` — full existing suite passes, including the two new files (22 assertions)
- [x] `covr::package_coverage()` confirms the coverage numbers above and no regressions elsewhere


---
_Generated by [Claude Code](https://claude.ai/code/session_019V3CHRGSzcEu3k6tpUFv56)_