### PR TITLE
Add unit tests for aaa-class-GCIMSSample.R; fix GCIMSChromatogram() baseline/peaks bug

### DIFF
--- a/R/aaa-class-GCIMSChromatogram.R
+++ b/R/aaa-class-GCIMSChromatogram.R
@@ -73,7 +73,7 @@ GCIMSChromatogram <- function(
     drift_time_ms = NA_real_, description = "",
     baseline = NULL, peaks = NULL, peaks_debug_info = NULL) {
   methods::new("GCIMSChromatogram", retention_time, intensity, drift_time_idx,
-               drift_time_ms, description, baseline = NULL, peaks = NULL,
-               peaks_debug_info = NULL)
+               drift_time_ms, description, baseline = baseline, peaks = peaks,
+               peaks_debug_info = peaks_debug_info)
 }
 

--- a/tests/testthat/test-aaa-class-GCIMSChromatogram.R
+++ b/tests/testthat/test-aaa-class-GCIMSChromatogram.R
@@ -1,0 +1,41 @@
+test_that("GCIMSChromatogram() sets the mandatory slots", {
+  ch <- GCIMSChromatogram(retention_time = 1:3, intensity = c(10, 20, 30))
+
+  expect_s4_class(ch, "GCIMSChromatogram")
+  expect_equal(rtime(ch), 1:3)
+  expect_equal(intensity(ch), c(10, 20, 30), ignore_attr = TRUE)
+  expect_null(baseline(ch, .error_if_missing = FALSE))
+})
+
+test_that("GCIMSChromatogram() forwards baseline, peaks and peaks_debug_info to the object", {
+  # Regression test: the constructor used to hardcode baseline/peaks/peaks_debug_info
+  # to NULL in the methods::new() call, silently discarding these arguments.
+  peaks_df <- S4Vectors::DataFrame(dt_apex_ms = 5, rt_apex_s = 10)
+
+  ch <- GCIMSChromatogram(
+    retention_time = 1:3,
+    intensity = c(10, 20, 30),
+    baseline = c(1, 2, 3),
+    peaks = peaks_df,
+    peaks_debug_info = list(foo = "bar")
+  )
+
+  expect_equal(baseline(ch), c(`1` = 1, `2` = 2, `3` = 3))
+  expect_equal(nrow(peaks(ch)), 1L)
+  expect_equal(peaks(ch)$dt_apex_ms, 5)
+  expect_equal(ch@peaks_debug_info, list(foo = "bar"))
+})
+
+test_that("GCIMSChromatogram() errors when retention_time and intensity lengths differ", {
+  expect_error(
+    GCIMSChromatogram(retention_time = 1:3, intensity = c(1, 2)),
+    "length"
+  )
+})
+
+test_that("GCIMSChromatogram() errors when baseline length does not match", {
+  expect_error(
+    GCIMSChromatogram(retention_time = 1:3, intensity = c(1, 2, 3), baseline = c(1, 2)),
+    "length"
+  )
+})

--- a/tests/testthat/test-aaa-class-GCIMSSample-methods.R
+++ b/tests/testthat/test-aaa-class-GCIMSSample-methods.R
@@ -1,0 +1,92 @@
+make_sample <- function() {
+  GCIMSSample(drift_time = 1:2, retention_time = 1:3, data = matrix(1:6, nrow = 2, ncol = 3))
+}
+
+test_that("initialize() errors when extra arguments are unnamed", {
+  expect_error(
+    methods::new(
+      "GCIMSSample",
+      drift_time = 1:2, retention_time = 1:3, data = matrix(1:6, 2, 3),
+      "nitrogen"
+    ),
+    "All extra arguments should be named"
+  )
+})
+
+test_that("[.GCIMSSample with both indices missing returns the object unchanged", {
+  x <- make_sample()
+  expect_identical(x[], x)
+})
+
+test_that("[.GCIMSSample subsets by drift time (i) and retention time (j)", {
+  x <- make_sample()
+
+  by_dt <- x[1, ]
+  expect_equal(dim(by_dt), c(1L, 3L))
+  expect_equal(dtime(by_dt), 1)
+
+  by_rt <- x[, 1:2]
+  expect_equal(dim(by_rt), c(2L, 2L))
+  expect_equal(rtime(by_rt), 1:2)
+})
+
+test_that("[.GCIMSSample validates logical index lengths", {
+  x <- make_sample()
+
+  expect_error(
+    x[c(TRUE, FALSE, TRUE), ],
+    "Incorrect number of logical values provided to subset drift time"
+  )
+  expect_error(
+    x[, c(TRUE, FALSE)],
+    "Incorrect number of logical values provided to subset retention time"
+  )
+})
+
+test_that("dim.GCIMSSample() returns the dimensions of the data matrix", {
+  x <- make_sample()
+  expect_equal(dim(x), c(2L, 3L))
+})
+
+test_that("subset.GCIMSSample() also subsets the baseline when it is set", {
+  x <- make_sample()
+  baseline(x) <- matrix(0, nrow = 2, ncol = 3)
+
+  xs <- subset.GCIMSSample(x, dt_idx = 1)
+
+  expect_equal(dim(baseline(xs, .error_if_missing = FALSE)), c(1L, 3L))
+})
+
+test_that("getChromatogram() errors when the aggregate function returns the wrong length", {
+  x <- make_sample()
+  expect_error(
+    getChromatogram(x, aggregate = function(m) 1),
+    "aggregation outcome should be a vector of length 3"
+  )
+})
+
+test_that("getChromatogram() propagates the sample's baseline, aggregated the same way as intensity", {
+  x <- make_sample()
+  baseline(x) <- matrix(c(1, 2, 3, 4, 5, 6), nrow = 2, ncol = 3)
+
+  ch <- getChromatogram(x)
+
+  expect_equal(baseline(ch), colSums(baseline(x)), ignore_attr = TRUE)
+})
+
+test_that("getSpectrum() errors when the aggregate function returns the wrong length", {
+  x <- make_sample()
+  expect_error(
+    getSpectrum(x, aggregate = function(m) 1),
+    "aggregation outcome should be a vector of length 2"
+  )
+})
+
+test_that("getSpectrum() propagates the sample's baseline, aggregated the same way as intensity", {
+  x <- make_sample()
+  baseline(x) <- matrix(c(1, 2, 3, 4, 5, 6), nrow = 2, ncol = 3)
+
+  sp <- getSpectrum(x)
+
+  expect_equal(baseline(sp), rowSums(baseline(x)), ignore_attr = TRUE)
+})


### PR DESCRIPTION
## Summary
- Add `tests/testthat/test-aaa-class-GCIMSSample-methods.R` covering the `"[.GCIMSSample"` subsetter (index normalization, logical-index length validation), `dim.GCIMSSample()`, `subset.GCIMSSample()`'s baseline handling, and the aggregate-length-validation / baseline-propagation branches of `getChromatogram()` and `getSpectrum()`. Brings `aaa-class-GCIMSSample.R` from 74.1% to 100% line coverage.
- **Bug fix**: while verifying `getChromatogram()`'s baseline propagation, found that `GCIMSChromatogram()` (`R/aaa-class-GCIMSChromatogram.R`) hardcoded `baseline = NULL, peaks = NULL, peaks_debug_info = NULL` in its `methods::new()` call instead of forwarding its own `baseline`/`peaks`/`peaks_debug_info` arguments. This silently discarded any baseline/peaks passed to the constructor — including from `getChromatogram()`, which relies on this to carry a sample's estimated baseline into the returned chromatogram. `baseline(chromatogram)` would always error with "Please use estimateBaseline() first" even when a baseline had been supplied. `GCIMSSpectrum()` did not have this bug (it forwards `...` correctly). Fixed to pass the arguments through.
- Add `tests/testthat/test-aaa-class-GCIMSChromatogram.R` with regression tests pinning the fix (baseline/peaks/peaks_debug_info round-trip through the constructor) plus basic validation-error tests. Brings `aaa-class-GCIMSChromatogram.R` from 0% to 100% line coverage.

## Test plan
- [x] `testthat::test_file()` on both new test files — 10 and 14 assertions pass respectively
- [x] Full suite `testthat::test_local(".")` — 446 passing, 1 pre-existing skip, 0 failures
- [x] `covr::package_coverage()` confirms both files at 100% coverage; overall package coverage 67.48% → 68.87%


---
_Generated by [Claude Code](https://claude.ai/code/session_019V3CHRGSzcEu3k6tpUFv56)_