### PR TITLE
Fix silent data loss when reloading a moved on-disk dataset; add DelayedDatasetDisk tests

### DIFF
--- a/R/aaa-class-DelayedDatasetDisk.R
+++ b/R/aaa-class-DelayedDatasetDisk.R
@@ -118,7 +118,7 @@ DelayedDatasetDisk <- R6::R6Class(
       if (!is.null(override_current_dir)) {
         old_scratch_dir <- dirname(override_current_dir)
         real_old_scratch_dir <- private$scratch_dir
-        old_current_dir <- basename(override_current_dir)
+        old_current_dir <- override_current_dir
       } else {
         old_scratch_dir <- private$scratch_dir
         real_old_scratch_dir <- private$scratch_dir

--- a/tests/testthat/test-DelayedDatasetDisk.R
+++ b/tests/testthat/test-DelayedDatasetDisk.R
@@ -164,3 +164,87 @@ test_that("realize() keeps the previous directory when keep_intermediate = TRUE"
 
   expect_true(dir.exists(dir_before))
 })
+
+test_that("getSample() errors with a clear message when the sample file is missing", {
+  ds <- make_disk_dataset(n = 1)
+  unlink(file.path(ds$getCurrentDir(), "sample_a.rds"))
+
+  expect_error(ds$getSample("a", dataset = list()), "File not found")
+})
+
+test_that("checkSampleFiles() returns character(0) when nothing has been realized yet", {
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  ds <- DelayedDatasetDisk$new(
+    samples = c(s1 = sample_file),
+    scratch_dir = new_scratch_dir(),
+    sample_class = "GCIMSSample"
+  )
+
+  expect_null(ds$getCurrentDir())
+  expect_equal(ds$checkSampleFiles(), character(0))
+})
+
+test_that("updateScratchDir() is a no-op when the new scratch dir equals the current one", {
+  ds <- make_disk_dataset(n = 1)
+  same_dir <- ds$scratchDir
+
+  expect_null(ds$updateScratchDir(same_dir, dataset = list()))
+  expect_equal(ds$scratchDir, same_dir)
+})
+
+test_that("updateScratchDir() just switches the scratch dir when nothing has been saved yet", {
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  ds <- DelayedDatasetDisk$new(
+    samples = c(s1 = sample_file),
+    scratch_dir = new_scratch_dir(),
+    sample_class = "GCIMSSample"
+  )
+  new_dir <- new_scratch_dir()
+
+  ds$updateScratchDir(new_dir, dataset = list())
+
+  expect_equal(ds$scratchDir, new_dir)
+  expect_null(ds$getCurrentDir())
+})
+
+test_that("updateScratchDir(override_current_dir=) copies sample files from the overridden location", {
+  # Regression test: override_current_dir used to be reduced to basename(),
+  # so dir.exists(old_current_dir) was checked against a relative path and
+  # (almost) always FALSE, silently skipping the file copy. This is the code
+  # path used by GCIMSDataset$new_from_saved_dir() to reload a dataset whose
+  # directory has moved.
+  ds <- make_disk_dataset(n = 1)
+  old_dir <- ds$getCurrentDir()
+  new_dir <- new_scratch_dir()
+
+  ds$updateScratchDir(new_dir, dataset = list(), override_current_dir = old_dir)
+
+  expect_equal(ds$scratchDir, new_dir)
+  expect_true(file.exists(file.path(ds$getCurrentDir(), "sample_a.rds")))
+  s <- ds$getSample("a", dataset = list())
+  expect_true(all(intensity(s) == 1))
+})
+
+test_that("the sampleNames setter is a no-op when nothing has been realized yet", {
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  ds <- DelayedDatasetDisk$new(
+    samples = c(s1 = sample_file),
+    scratch_dir = new_scratch_dir(),
+    sample_class = "GCIMSSample"
+  )
+
+  expect_null(ds$getCurrentDir())
+  expect_no_error(ds$sampleNames <- c("renamed"))
+})
+
+test_that("realize() aborts with a clear message when the first queued operation is not read_sample", {
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  ds <- DelayedDatasetDisk$new(
+    samples = c(s1 = sample_file),
+    scratch_dir = new_scratch_dir(),
+    sample_class = "GCIMSSample"
+  )
+  ds$appendDelayedOp(DelayedOperation(name = "not_read_sample", fun = function(x) x))
+
+  expect_error(ds$realize(dataset = list()), "should have been named")
+})


### PR DESCRIPTION
## Summary
- **Bug fix**: `DelayedDatasetDisk$updateScratchDir()` (`R/aaa-class-DelayedDatasetDisk.R`) reduced `override_current_dir` to `basename(override_current_dir)` instead of keeping the full path. The subsequent `dir.exists(old_current_dir)` check then compared a relative path against the process's working directory and was (almost) always `FALSE`, silently taking the "nothing saved yet" early-return branch and skipping the sample-file copy entirely.
  - This is the exact code path used by `GCIMSDataset$new_from_saved_dir()` to reload an on-disk dataset whose directory has moved — its documented purpose ("Useful when loading samples from a saved directory... the directory was moved since it was saved").
  - Reproduced end-to-end: save an on-disk dataset, move its directory, reload with a new `scratch_dir` via `new_from_saved_dir()` — the new scratch directory ends up empty and `getSample()` then fails with "File not found: 'sample_file' should exist".
  - Fixed by keeping `override_current_dir` as the full path, matching the non-override branch (which already uses a full path via `private$currentHashedDir()`).
- Add regression test pinning the fix (`updateScratchDir(override_current_dir=)` actually copies the files across).
- Add tests for other branches found while investigating: `getSample()`'s missing-file error, `checkSampleFiles()`/`updateScratchDir()`/`sampleNames<-` before anything has been realized (unrealized on-disk datasets), and `realize()`'s abort when the first queued operation isn't named `read_sample`.
- Brings `aaa-class-DelayedDatasetDisk.R` from 73.0% to 80.5% line coverage. The remaining gaps are a `file.copy`/`unlink` failure branch (needs mocking filesystem failures), dead defensive code unreachable through the public API, and code that only runs inside `BiocParallel::bpmapply`'s forked worker processes, which `covr` cannot instrument.

## Test plan
- [x] `testthat::test_file("tests/testthat/test-DelayedDatasetDisk.R")` — 41/41 assertions pass
- [x] Full suite `testthat::test_local(".")` — 423 passing, 1 pre-existing skip, 0 failures
- [x] `covr::package_coverage()` confirms `aaa-class-DelayedDatasetDisk.R` at 80.5% (up from 73.0%)
- [x] Manually reproduced the bug end-to-end before the fix, and confirmed the same scenario now works after the fix


---
_Generated by [Claude Code](https://claude.ai/code/session_019V3CHRGSzcEu3k6tpUFv56)_