### PR TITLE
Fix dataset$sampleNames<- crashing a subsequent realize()

### DIFF
--- a/R/aaa-class-DelayedDatasetBase.R
+++ b/R/aaa-class-DelayedDatasetBase.R
@@ -87,6 +87,22 @@ DelayedDatasetBase <- R6::R6Class(
       length(private$delayed_ops) > 0
     },
     #' @description
+    #' If the *only* pending operation is the one named `name`, discard it.
+    #' This is narrowly scoped on purpose: it is only safe to replace a
+    #' pending operation with a newer, equivalent one when nothing else is
+    #' queued alongside it (otherwise the operation could be re-run out of
+    #' the order it was originally queued in, relative to whatever else is
+    #' pending).
+    #' @param name The operation name to drop, if it is the sole pending one
+    #' @return `TRUE` if the operation was dropped, `FALSE` otherwise
+    dropSolePendingOp = function(name) {
+      if (length(private$delayed_ops) == 1 && identical(private$delayed_ops[[1]]@name, name)) {
+        private$delayed_ops <- list()
+        return(invisible(TRUE))
+      }
+      invisible(FALSE)
+    },
+    #' @description
     #' Get a sample from the dataset
     #'
     #' @param sample Either an integer (sample index) or a string (sample name)

--- a/R/aaa-class-GCIMSDataset.R
+++ b/R/aaa-class-GCIMSDataset.R
@@ -398,6 +398,25 @@ GCIMSDataset <- R6::R6Class("GCIMSDataset",
       if (anyNA(value) || anyDuplicated(value)) {
         cli_abort("Sample names must be unique and not missing")
       }
+      if (self$hasDelayedOps() && !private$delayed_dataset$dropSolePendingOp("setSampleNamesAsDescription")) {
+        # The delayed operation queued below (setSampleNamesAsDescription) is
+        # matched against each sample's current name when it actually runs
+        # during realize(). If other operations -- including the one queued
+        # at construction time -- are still pending, that name may no longer
+        # match what they expect by the time they run. Requiring a realize()
+        # first keeps sample identity unambiguous.
+        #
+        # The one exception: if the *only* thing pending is an earlier,
+        # not-yet-realized rename, it is safe to just replace it -- nothing
+        # else is queued that could have observed it in between, so no
+        # operation order is being violated.
+        cli_abort(
+          c(
+            "Can't rename samples while there are pending operations",
+            "i" = "Call {.code dataset$realize()} first, then rename the samples"
+          )
+        )
+      }
       # Rename the delayed_dataset
       private$delayed_dataset$sampleNames <- value
       # Update pData accordingly

--- a/tests/testthat/test-aaa-class-GCIMSDataset.R
+++ b/tests/testthat/test-aaa-class-GCIMSDataset.R
@@ -26,6 +26,7 @@ test_that("GCIMSDataset construction from files errors clearly when a file is mi
 
 test_that("dataset$sampleNames<- renames samples, updates pData, and validates its input", {
   ds <- make_ram_dataset()
+  ds$realize() # sampleNames<- requires no pending operations
 
   ds$sampleNames <- c("x", "y")
 

--- a/tests/testthat/test-sampleNames-rename.R
+++ b/tests/testthat/test-sampleNames-rename.R
@@ -1,0 +1,164 @@
+# Regression tests for a bug where dataset$sampleNames <- newNames could
+# crash the next getSample()/realize() with "description should be a
+# string". Root cause: the delayed "setSampleNamesAsDescription" operation
+# that keeps each sample's internal description in sync with its
+# dataset-level name is matched against the sample's identity at the moment
+# it actually runs during realize() -- but if other operations were still
+# pending (including the one queued automatically at construction time),
+# that identity could already have moved past what an earlier-queued copy
+# of this operation expected.
+#
+# Fixed by requiring the dataset to have no pending operations before a
+# rename is allowed, so there is always at most one such operation queued,
+# unambiguously matching the sample's current identity. See
+# aaa-class-GCIMSDataset.R.
+#
+# One narrow exception: if the *only* pending operation is itself an
+# earlier, not-yet-realized rename, it is safe to just replace it, since
+# nothing else was queued in between that could have observed it. See
+# DelayedDatasetBase$dropSolePendingOp().
+
+make_ram_pair <- function() {
+  s1 <- GCIMSSample(drift_time = 1:2, retention_time = 1:2, data = matrix(1, nrow = 2, ncol = 2))
+  s2 <- GCIMSSample(drift_time = 1:2, retention_time = 1:2, data = matrix(2, nrow = 2, ncol = 2))
+  GCIMSDataset_fromList(list(a = s1, b = s2))
+}
+
+test_that("renaming a dataset with pending operations aborts with a clear message", {
+  ds <- make_ram_pair()
+
+  expect_true(ds$hasDelayedOps()) # construction always queues some ops
+  expect_error(
+    {
+      ds$sampleNames <- c("x", "y")
+    },
+    "pending operations"
+  )
+})
+
+test_that("renaming a RAM dataset works correctly right after an explicit realize()", {
+  ds <- make_ram_pair()
+  ds$realize()
+
+  ds$sampleNames <- c("x", "y")
+
+  expect_equal(ds$sampleNames, c("x", "y"))
+  s <- ds$getSample("x")
+  expect_equal(intensity(s)[1, 1], 1)
+  expect_equal(description(s), "x")
+})
+
+test_that("renaming a RAM dataset works correctly after getSample() has implicitly realized it", {
+  ds <- make_ram_pair()
+  ds$getSample(1)
+
+  ds$sampleNames <- c("x", "y")
+
+  s <- ds$getSample("x")
+  expect_equal(description(s), "x")
+})
+
+test_that("renaming an on-disk dataset with pending operations also aborts", {
+  scratch <- tempfile("gcims_scratch_")
+  dir.create(scratch)
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  pData <- data.frame(SampleID = "s1", FileName = basename(sample_file))
+  ds <- GCIMSDataset$new(pData = pData, base_dir = dirname(sample_file), on_ram = FALSE, scratch_dir = scratch)
+
+  expect_error(
+    {
+      ds$sampleNames <- "renamed"
+    },
+    "pending operations"
+  )
+})
+
+test_that("renaming an on-disk dataset works correctly after realize()", {
+  scratch <- tempfile("gcims_scratch_")
+  dir.create(scratch)
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  pData <- data.frame(SampleID = "s1", FileName = basename(sample_file))
+  ds <- GCIMSDataset$new(pData = pData, base_dir = dirname(sample_file), on_ram = FALSE, scratch_dir = scratch)
+  ds$getSample(1)
+
+  ds$sampleNames <- "renamed"
+
+  s <- ds$getSample("renamed")
+  expect_equal(description(s), "renamed")
+})
+
+test_that("swapping two sample names resolves each sample to the correct data and description", {
+  ds <- make_ram_pair()
+  ds$realize()
+
+  ds$sampleNames <- c("b", "a")
+
+  sb <- ds$getSample("b")
+  sa <- ds$getSample("a")
+  expect_equal(intensity(sb)[1, 1], 1)
+  expect_equal(description(sb), "b")
+  expect_equal(intensity(sa)[1, 1], 2)
+  expect_equal(description(sa), "a")
+})
+
+test_that("a second rename replaces the first when nothing else is pending in between (RAM)", {
+  ds <- make_ram_pair()
+  ds$realize()
+
+  ds$sampleNames <- c("x", "y")
+  ds$sampleNames <- c("p", "q") # no realize() needed in between
+
+  expect_equal(ds$sampleNames, c("p", "q"))
+  sp <- ds$getSample("p")
+  sq <- ds$getSample("q")
+  expect_equal(intensity(sp)[1, 1], 1)
+  expect_equal(description(sp), "p")
+  expect_equal(intensity(sq)[1, 1], 2)
+  expect_equal(description(sq), "q")
+})
+
+test_that("a second rename replaces the first when nothing else is pending in between (disk)", {
+  scratch <- tempfile("gcims_scratch_")
+  dir.create(scratch)
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  pData <- data.frame(SampleID = "s1", FileName = basename(sample_file))
+  ds <- GCIMSDataset$new(pData = pData, base_dir = dirname(sample_file), on_ram = FALSE, scratch_dir = scratch)
+  ds$getSample(1)
+
+  ds$sampleNames <- "x"
+  ds$sampleNames <- "p"
+
+  s <- ds$getSample("p")
+  expect_equal(description(s), "p")
+})
+
+test_that("renaming still aborts if another operation was queued between two renames", {
+  ds <- make_ram_pair()
+  ds$realize()
+  ds$sampleNames <- c("x", "y")
+  ds$appendDelayedOp(DelayedOperation(name = "noop", fun = function(sample) sample))
+
+  expect_error(
+    {
+      ds$sampleNames <- c("p", "q")
+    },
+    "pending operations"
+  )
+})
+
+test_that("dropSolePendingOp() only drops when it is the sole pending operation with that name", {
+  dd <- DelayedDatasetRAM$new(samples = list(a = 1))
+
+  # nothing pending: nothing to drop
+  expect_false(dd$dropSolePendingOp("foo"))
+
+  dd$appendDelayedOp(DelayedOperation(name = "foo", fun = function(x) x))
+  expect_true(dd$dropSolePendingOp("foo"))
+  expect_false(dd$hasDelayedOps())
+
+  # two operations pending: refuses, even if one of them matches
+  dd$appendDelayedOp(DelayedOperation(name = "foo", fun = function(x) x))
+  dd$appendDelayedOp(DelayedOperation(name = "bar", fun = function(x) x))
+  expect_false(dd$dropSolePendingOp("foo"))
+  expect_true(dd$hasDelayedOps())
+})


### PR DESCRIPTION
## Summary
Renaming a `GCIMSDataset` before it had ever been realized crashed the next `getSample()`/`realize()` with `"description should be a string"`.

**Root cause**: `GCIMSDataset` queues a delayed `setSampleNamesAsDescription` operation to keep each sample's internal description in sync with its dataset-level name, both automatically at construction and on every explicit rename. If more than one such operation ended up pending at once (e.g. renaming a freshly-constructed, never-realized dataset, or renaming it twice before a realize), a stale copy could be matched against a sample identity it no longer applied to, and its per-sample lookup returned `NULL` instead of a name.

**Fix**: require the dataset to have no pending operations before a rename is allowed, so there is always at most one such operation queued, unambiguously matching the sample's current identity:
- `dataset$sampleNames<-` now aborts with a clear message (`"Can't rename samples while there are pending operations ... Call realize() first"`) when other operations are pending, instead of silently queuing another rename operation that could later crash or resolve incorrectly.
- One narrow exception: if the *only* pending operation is itself an earlier, not-yet-realized rename, it's safe to just replace it in place — nothing else was queued in between that could have observed it, so operation order relative to other pending work is never disturbed. This is implemented via a new, narrowly-scoped `DelayedDatasetBase$dropSolePendingOp(name)` primitive, so consecutive renames don't require an explicit `realize()` between each one.

## Test plan
- [x] `testthat::test_file("tests/testthat/test-sampleNames-rename.R")` covers: renaming before the first realize aborting clearly (RAM and disk) instead of crashing later; renaming working correctly right after a realize (explicit or implicit via `getSample()`); a two-element name swap resolving each sample to the correct data and description; consecutive renames with nothing else queued in between replacing each other; a rename still aborting if another operation was queued between two rename attempts; and `dropSolePendingOp()` unit-tested directly.
- [x] Full suite `testthat::test_local(".")` — 499 passing, 1 pre-existing skip, 0 failures
