### PR TITLE
Stop running CI twice per push on branches with an open PR

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -22,7 +22,12 @@
 
 on:
   push:
+    branches: [master]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 name: R-CMD-check-bioc
 


### PR DESCRIPTION
## Summary
- Analyzed the last 30 `check-bioc.yml` runs: every commit pushed to a branch with an open PR triggered two complete, duplicate runs on the same commit SHA — one from `push`, one from `pull_request` — because `push:` had no `branches:` filter. Confirmed by cross-referencing run `event`/`head_sha` pairs (e.g. runs #647/#648, #645/#646, #643/#644 all share a SHA, ~14 minutes apart).
- Every gate inside the workflow (`covr`, `pkgdown` deploy) already only runs on `github.ref == 'refs/heads/master'`, confirming `push` was only ever meant to cover `master`; `pull_request` already covers every PR-branch commit.
- Scope `push:` to `branches: [master]`, so PR-branch pushes only run once (via `pull_request`), while `master` pushes are unaffected.
- Add a `concurrency` group (`cancel-in-progress: true`) so a rapid string of commits (rebases, force-pushes, quick fixups) cancels stale in-progress runs on the same branch/PR instead of all of them running to completion.

Both changes are trigger/scheduling-only — nothing about what an individual run actually does changes, so there's no risk to test/build correctness.

## Test plan
- [x] Validated the modified YAML parses correctly
- [x] This PR itself is a live test: since `push` is now scoped to `master`, this branch's pushes should no longer trigger a duplicate `push`-triggered run alongside the `pull_request`-triggered one


---
_Generated by [Claude Code](https://claude.ai/code/session_019V3CHRGSzcEu3k6tpUFv56)_