### PR TITLE
Add unit tests for several small, previously-0%-covered files

### DIFF
--- a/tests/testthat/test-create_annotations_table.R
+++ b/tests/testthat/test-create_annotations_table.R
@@ -1,0 +1,47 @@
+make_samples_dir <- function() {
+  d <- tempfile("annot_")
+  dir.create(d)
+  dir.create(file.path(d, "sub"))
+  file.create(file.path(d, "a.mea"))
+  file.create(file.path(d, "b.mea.gz"))
+  file.create(file.path(d, "c.txt"))
+  file.create(file.path(d, "sub", "d.mea"))
+  d
+}
+
+test_that("create_annotations_table() lists matching files recursively by default, stripping .mea/.mea.gz from SampleID", {
+  d <- make_samples_dir()
+
+  out <- create_annotations_table(d, verbose = FALSE)
+
+  expect_s3_class(out, "tbl_df")
+  expect_named(out, c("SampleID", "FileName"))
+  expect_setequal(out$FileName, c("a.mea", "b.mea.gz", file.path("sub", "d.mea")))
+  expect_setequal(out$SampleID, c("a", "b", "d"))
+})
+
+test_that("create_annotations_table(recursive = FALSE) only lists files in the top-level directory", {
+  d <- make_samples_dir()
+
+  out <- create_annotations_table(d, recursive = FALSE, verbose = FALSE)
+
+  expect_setequal(out$FileName, c("a.mea", "b.mea.gz"))
+})
+
+test_that("create_annotations_table() respects a custom glob", {
+  d <- make_samples_dir()
+
+  out <- create_annotations_table(d, glob = "*.mea", recursive = FALSE, verbose = FALSE)
+
+  expect_equal(out$FileName, "a.mea")
+})
+
+test_that("create_annotations_table(verbose = TRUE) informs how many samples were found", {
+  d <- make_samples_dir()
+
+  expect_message(
+    out <- create_annotations_table(d, verbose = TRUE),
+    "3 samples"
+  )
+  expect_equal(nrow(out), 3)
+})

--- a/tests/testthat/test-dtime-rtime-GCIMSDataset.R
+++ b/tests/testthat/test-dtime-rtime-GCIMSDataset.R
@@ -1,0 +1,27 @@
+make_dataset <- function() {
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  annot <- data.frame(SampleID = "Sample1", FileName = basename(sample_file))
+  GCIMSDataset$new(annot, base_dir = dirname(sample_file), on_ram = TRUE)
+}
+
+test_that("dtime()/rtime() realize a never-realized dataset to compute the reference axes", {
+  ds <- make_dataset()
+
+  dt <- dtime(ds)
+  rt <- rtime(ds)
+
+  expect_true(length(dt) > 0)
+  expect_true(length(rt) > 0)
+  expect_false(ds$hasDelayedOps())
+})
+
+test_that("dtime()/rtime() with sample= return that sample's own axis", {
+  ds <- make_dataset()
+
+  dt_sample <- dtime(ds, sample = 1)
+  rt_sample <- rtime(ds, sample = "Sample1")
+
+  s <- ds$getSample(1)
+  expect_equal(dt_sample, dtime(s))
+  expect_equal(rt_sample, rtime(s))
+})

--- a/tests/testthat/test-filter-GCIMSDataset.R
+++ b/tests/testthat/test-filter-GCIMSDataset.R
@@ -1,0 +1,25 @@
+make_dataset <- function() {
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  annot <- data.frame(SampleID = "Sample1", FileName = basename(sample_file))
+  GCIMSDataset$new(annot, base_dir = dirname(sample_file), on_ram = TRUE)
+}
+
+test_that("filterRt() queues a retention-time filter applied on realize", {
+  ds <- make_dataset()
+
+  filterRt(ds, rt_range = c(5, 50))
+  s <- ds$getSample(1)
+
+  expect_true(min(rtime(s)) >= 5)
+  expect_true(max(rtime(s)) <= 50)
+})
+
+test_that("filterDt() queues a drift-time filter applied on realize", {
+  ds <- make_dataset()
+
+  filterDt(ds, dt_range = c(5, 10))
+  s <- ds$getSample(1)
+
+  expect_true(min(dtime(s)) >= 5)
+  expect_true(max(dtime(s)) <= 10)
+})

--- a/tests/testthat/test-pData-GCIMSDataset.R
+++ b/tests/testthat/test-pData-GCIMSDataset.R
@@ -1,0 +1,48 @@
+make_dataset <- function() {
+  sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
+  pdat <- data.frame(SampleID = "s1", FileName = basename(sample_file))
+  GCIMSDataset$new(pData = pdat, base_dir = dirname(sample_file), on_ram = TRUE)
+}
+
+test_that("pData() returns the phenotype data as a tibble", {
+  ds <- make_dataset()
+
+  out <- pData(ds)
+
+  expect_s3_class(out, "tbl_df")
+  expect_equal(as.character(out$SampleID), "s1")
+})
+
+test_that("pData<- replaces the phenotype data, keeping extra annotation columns", {
+  ds <- make_dataset()
+  newp <- pData(ds)
+  newp$Group <- "A"
+
+  pData(ds) <- newp
+
+  expect_equal(pData(ds)$Group, "A")
+})
+
+test_that("pData<- errors when the number of rows does not match", {
+  ds <- make_dataset()
+
+  expect_error(
+    {
+      pData(ds) <- data.frame(SampleID = c("s1", "s2"), FileName = c("a", "b"))
+    },
+    "Number of rows expected"
+  )
+})
+
+test_that("pData<- warns when FileName is changed", {
+  ds <- make_dataset()
+  newp <- pData(ds)
+  newp$FileName <- "different.mea.gz"
+
+  expect_warning(
+    {
+      pData(ds) <- newp
+    },
+    "FileName changed"
+  )
+})

--- a/tests/testthat/test-show-GCIMSSample.R
+++ b/tests/testthat/test-show-GCIMSSample.R
@@ -1,0 +1,33 @@
+test_that("show() prints axis ranges, step and point counts for a multi-point sample", {
+  s <- GCIMSSample(
+    drift_time = seq(0, 10, by = 0.5),
+    retention_time = seq(0, 20, by = 1),
+    data = matrix(1, nrow = 21, ncol = 21)
+  )
+
+  out <- capture.output(print(s))
+
+  expect_equal(
+    out,
+    c(
+      "A GCIMS Sample",
+      " with drift time from 0 to 10 ms (step: 0.5 ms, points: 21)",
+      " with retention time from 0 to 20 s (step: 1 s, points: 21)"
+    )
+  )
+})
+
+test_that("show() handles a single-point axis without a step", {
+  s <- GCIMSSample(drift_time = 5, retention_time = 10, data = matrix(1, 1, 1))
+
+  out <- capture.output(print(s))
+
+  expect_equal(
+    out,
+    c(
+      "A GCIMS Sample",
+      " with drift time from 5 to 5 ms (step: NaN ms, points: 1)",
+      " with retention time from 10 to 10 s (step: NaN s, points: 1)"
+    )
+  )
+})


### PR DESCRIPTION
## Summary
- `show-GCIMSSample.R`: tests for `show()`'s multi-point and single-point axis rendering.
- `create_annotations_table.R`: tests for recursive vs. non-recursive listing, a custom `glob`, `SampleID` stripping of the `.mea`/`.mea.gz` suffix, and the `verbose = TRUE` message. Reaches 100% coverage.
- `pData-GCIMSDataset.R`: tests for `pData()`/`pData<-` — the tibble getter, replacing pData while keeping extra annotation columns, the row-count validation error, and the FileName-change warning. Reaches 100% coverage.
- `filter-GCIMSDataset.R`: tests for `filterRt()`/`filterDt()` applying their range filters on realize. Reaches 100% coverage.
- `dtime-rtime-GCIMSDataset.R`: tests for `dtime()`/`rtime()` implicitly realizing a never-realized dataset, and their `sample=` per-sample lookup path.

Remaining gaps in `show-GCIMSSample.R` (a zero-length axis) and `dtime-rtime-GCIMSDataset.R` (`.extract_dtime_rtime_fun_extract`/`.extract_dtime_rtime_fun_aggregate`) are either unreachable through the public API/S4 validation, or run inside `BiocParallel::bpmapply`'s forked worker processes, which `covr` cannot instrument (same limitation identified in earlier coverage PRs).

## Test plan
- [x] Ran each new test file individually — all pass
- [x] Full suite `testthat::test_local(".")` — 523 passing, 1 pre-existing skip, 0 failures
- [x] `covr::package_coverage()` confirms the reported per-file numbers; overall package coverage 70.52% → 73.16%


---
_Generated by [Claude Code](https://claude.ai/code/session_019V3CHRGSzcEu3k6tpUFv56)_