### PR TITLE
Add unit tests for alignPlots() and the getTIS/getRIC/plotTIS/plotRIC family

### DIFF
--- a/tests/testthat/test-DelayedDatasetBase.R
+++ b/tests/testthat/test-DelayedDatasetBase.R
@@ -91,3 +91,46 @@ test_that("DelayedDatasetRAM$sampleNames setter renames samples and rejects dupl
     "unique and not missing"
   )
 })
+
+test_that("DelayedDatasetRAM requires a named samples list", {
+  expect_error(
+    DelayedDatasetRAM$new(samples = list(1, 2)),
+    "named list"
+  )
+})
+
+test_that("DelayedDatasetRAM$sampleNames setter rejects a length mismatch", {
+  ds <- DelayedDatasetRAM$new(samples = list(a = 1, b = 2))
+
+  expect_error(
+    {
+      ds$sampleNames <- c("x", "y", "z")
+    },
+    "not of length"
+  )
+})
+
+test_that("DelayedDatasetRAM$realize aborts with a clear message when an action returns the wrong class", {
+  # Registering SerialParam runs realize_one_sample_ram() in this same
+  # process, so covr can instrument its wrong-class-returned abort below --
+  # it would otherwise run invisibly inside a forked worker.
+  old_bpparam <- BiocParallel::bpparam()
+  BiocParallel::register(BiocParallel::SerialParam())
+  on.exit(BiocParallel::register(old_bpparam))
+
+  ds <- DelayedDatasetRAM$new(samples = list(a = 1), sample_class = "numeric")
+  ds$appendDelayedOp(DelayedOperation(name = "to_character", fun = function(x) as.character(x)))
+
+  expect_error(ds$realize(dataset = list()), "Invalid action")
+})
+
+test_that("realize() aborts with a clear message if called reentrantly", {
+  # can_realize is only FALSE transiently while realize_impl() runs (guarded
+  # by an on.exit() restore), so this defensive re-entrancy check can't be
+  # triggered through normal usage. Forced directly via R6 private access.
+  ds <- DelayedDatasetRAM$new(samples = list(a = 1))
+  ds$appendDelayedOp(DelayedOperation(name = "op", fun = function(x) x))
+  ds$.__enclos_env__$private$can_realize <- FALSE
+
+  expect_error(ds$realize(dataset = list()), "could not be realized")
+})

--- a/tests/testthat/test-DelayedDatasetDisk.R
+++ b/tests/testthat/test-DelayedDatasetDisk.R
@@ -27,6 +27,14 @@ test_that("DelayedDatasetDisk dumps a list of samples to disk on construction", 
 })
 
 test_that("GCIMSDataset(on_ram = FALSE) constructs a disk-backed dataset from files", {
+  # Registering SerialParam (instead of the default forking MulticoreParam)
+  # runs realize_one_sample_disk() in this same process, so covr can
+  # instrument its is_first_step branch below -- it would otherwise run
+  # invisibly inside a forked worker.
+  old_bpparam <- BiocParallel::bpparam()
+  BiocParallel::register(BiocParallel::SerialParam())
+  on.exit(BiocParallel::register(old_bpparam))
+
   sample_file <- system.file("extdata", "sample_formats", "small.mea.gz", package = "GCIMS")
   pData <- data.frame(SampleID = "s1", FileName = basename(sample_file))
   scratch <- new_scratch_dir()
@@ -136,6 +144,12 @@ test_that("subset() refuses to run with pending operations", {
 })
 
 test_that("realize() runs the queued operation, moves samples to a new directory, and cleans up the old one when keep_intermediate = FALSE", {
+  # Same SerialParam rationale as above: makes realize_one_sample_disk()'s
+  # existing-file branch and its saveRDS/file.copy decision visible to covr.
+  old_bpparam <- BiocParallel::bpparam()
+  BiocParallel::register(BiocParallel::SerialParam())
+  on.exit(BiocParallel::register(old_bpparam))
+
   ds <- make_disk_dataset(n = 1, keep_intermediate = FALSE)
   dir_before <- ds$getCurrentDir()
   ds$appendDelayedOp(DelayedOperation(
@@ -247,4 +261,90 @@ test_that("realize() aborts with a clear message when the first queued operation
   ds$appendDelayedOp(DelayedOperation(name = "not_read_sample", fun = function(x) x))
 
   expect_error(ds$realize(dataset = list()), "should have been named")
+})
+
+test_that("realize_one_sample_disk() copies the file as-is when nothing modifies the sample", {
+  # This is only reachable when current_filename != next_filename (so a copy
+  # is needed) while no queued op modifies the sample -- a combination that
+  # can't arise through the public API, since nextHashedDir()'s hash chain
+  # only advances (making next_filename differ from current_filename) when
+  # there IS a modifying op, which would also make needs_re_saving TRUE.
+  # Tested directly as a unit test of this internal function instead.
+  d1 <- new_scratch_dir()
+  d2 <- new_scratch_dir()
+  f1 <- file.path(d1, "sample_a.rds")
+  f2 <- file.path(d2, "sample_a.rds")
+  saveRDS(GCIMSSample(1:2, 1:2, matrix(1, 2, 2)), f1)
+  op <- DelayedOperation(name = "extract-only", fun = NULL, fun_extract = function(x) 1)
+
+  out <- realize_one_sample_disk(
+    sample_name = "a", current_filename = f1, next_filename = f2,
+    delayed_ops = list(op), is_first_step = FALSE, sample_class = "GCIMSSample"
+  )
+
+  expect_true(file.exists(f2))
+  expect_equal(out, list(1))
+})
+
+test_that("realize_one_sample_disk() errors clearly when the file.copy destination is unwritable", {
+  d1 <- new_scratch_dir()
+  f1 <- file.path(d1, "sample_a.rds")
+  saveRDS(GCIMSSample(1:2, 1:2, matrix(1, 2, 2)), f1)
+  f2_bad <- file.path(tempfile("nonexistent_dir_"), "sample_a.rds")
+  op <- DelayedOperation(name = "extract-only", fun = NULL, fun_extract = function(x) 1)
+
+  expect_error(
+    suppressWarnings(realize_one_sample_disk(
+      sample_name = "a", current_filename = f1, next_filename = f2_bad,
+      delayed_ops = list(op), is_first_step = FALSE, sample_class = "GCIMSSample"
+    )),
+    "Could not copy"
+  )
+})
+
+test_that("realize_one_sample_disk() errors clearly when the current sample file is missing", {
+  op <- DelayedOperation(name = "noop", fun = function(x) x)
+
+  expect_error(
+    realize_one_sample_disk(
+      sample_name = "a", current_filename = "/does/not/exist.rds", next_filename = "/tmp/out.rds",
+      delayed_ops = list(op), is_first_step = FALSE, sample_class = "GCIMSSample"
+    ),
+    "should exist"
+  )
+})
+
+test_that("updateScratchDir() errors clearly and restores the old scratch dir when file.copy fails", {
+  testthat::local_mocked_bindings(file.copy = function(...) FALSE, .package = "base")
+  ds <- make_disk_dataset(n = 1)
+  old_scratch <- ds$scratchDir
+
+  expect_error(ds$updateScratchDir(new_scratch_dir(), dataset = list()), "File copy failed")
+  expect_equal(ds$scratchDir, old_scratch)
+})
+
+test_that("subset() warns but continues when a sample file can't be deleted", {
+  testthat::local_mocked_bindings(unlink = function(...) 1L, .package = "base")
+  ds <- make_disk_dataset(n = 2)
+
+  expect_warning(ds$subset("a"), "Could not delete")
+  expect_equal(ds$sampleNames, "a")
+})
+
+test_that("rename_samples_and_files() is a no-op if the current directory has vanished", {
+  ds <- make_disk_dataset(n = 1)
+  unlink(ds$getCurrentDir(), recursive = TRUE)
+
+  ds$.__enclos_env__$private$rename_samples_and_files("b")
+
+  expect_equal(names(ds$.__enclos_env__$private$samples), "a")
+})
+
+test_that("nextHashedDir() equals currentHashedDir() when there are no pending operations", {
+  ds <- make_disk_dataset(n = 1)
+
+  expect_identical(
+    ds$.__enclos_env__$private$nextHashedDir(),
+    ds$.__enclos_env__$private$currentHashedDir()
+  )
 })

--- a/tests/testthat/test-align-GCIMSDataset.R
+++ b/tests/testthat/test-align-GCIMSDataset.R
@@ -60,6 +60,14 @@ test_that("align() honors an explicit reference_sample_idx", {
 })
 
 test_that("align() with align_dt = FALSE, align_ip = FALSE skips prealign without crashing", {
+  # Registering SerialParam (instead of the default forking MulticoreParam)
+  # runs the per-sample delayed operation in this same process, so covr can
+  # instrument .align_fun_extract()'s dt_kcorr fallback below -- it would
+  # otherwise run invisibly inside a forked worker.
+  old_bpparam <- BiocParallel::bpparam()
+  BiocParallel::register(BiocParallel::SerialParam())
+  on.exit(BiocParallel::register(old_bpparam))
+
   ds <- make_dataset()
   dt_before <- dtime(ds$getSample(1))
 
@@ -67,6 +75,9 @@ test_that("align() with align_dt = FALSE, align_ip = FALSE skips prealign withou
   ds$realize()
 
   expect_identical(dtime(ds$getSample(1)), dt_before)
+  # .align_fun_extract() falls back to dt_kcorr = 1 when prealign() (and
+  # therefore alignDt()) never ran, since no drift-time correction was
+  # ever recorded on the sample:
   expect_true(all(ds$align$dt_kcorr == 1))
 })
 
@@ -79,4 +90,27 @@ test_that("align(method_rt = 'pow') on a GCIMSDataset fails fast with a clear me
     align(ds, method_rt = "pow"),
     "pow.*is not on CRAN/Bioconductor"
   )
+})
+
+test_that("alignPlots() returns rt/dt correction plots and a dt_kcorr plot with the expected data", {
+  ds <- make_dataset()
+  align(ds, method_rt = "ptw", align_dt = TRUE, align_ip = TRUE)
+  ds$realize()
+
+  plots <- alignPlots(ds)
+
+  expect_named(plots, c("rt_diff_plot", "dt_diff_plot", "dt_kcorr_plot"))
+  for (p in plots) expect_s3_class(p, "ggplot")
+
+  expect_equal(plots$rt_diff_plot$labels$x, "Retention time (s)")
+  expect_equal(plots$rt_diff_plot$labels$y, "Ret. time correction (s)")
+  expect_setequal(unique(as.character(plots$rt_diff_plot$data$SampleID)), ds$sampleNames)
+
+  expect_equal(plots$dt_diff_plot$labels$x, "Drift time (ms)")
+  expect_equal(plots$dt_diff_plot$labels$y, "Drift time correction (ms)")
+  expect_setequal(unique(as.character(plots$dt_diff_plot$data$SampleID)), ds$sampleNames)
+
+  expect_equal(plots$dt_kcorr_plot$labels$x, "SampleID")
+  expect_equal(as.character(plots$dt_kcorr_plot$data$x), ds$sampleNames)
+  expect_equal(plots$dt_kcorr_plot$data$y, unname(ds$align$dt_kcorr))
 })

--- a/tests/testthat/test-getTIS_getRIC-GCIMSDataset.R
+++ b/tests/testthat/test-getTIS_getRIC-GCIMSDataset.R
@@ -1,0 +1,73 @@
+gauss <- function(x, center, height, sd) height * exp(-(x - center)^2 / (2 * sd^2))
+
+make_dataset <- function() {
+  dt <- seq(0, 4, by = 0.02) # 201 pts
+  rt <- seq(0, 50, by = 0.5) # 101 pts
+  make_s <- function(peak_dt, peak_rt) {
+    int_mat <- matrix(50, nrow = length(dt), ncol = length(rt)) +
+      outer(gauss(dt, peak_dt, 500, 0.1), gauss(rt, peak_rt, 1, 3))
+    GCIMSSample(drift_time = dt, retention_time = rt, data = int_mat)
+  }
+  s1 <- make_s(2, 25)
+  s2 <- make_s(2.2, 25)
+  GCIMSDataset$new_from_list(samples = list(s1 = s1, s2 = s2), on_ram = TRUE, scratch_dir = NULL)
+}
+
+test_that("getTIS()/getRIC() extract per-sample TIS and RIC matrices, keyed by SampleID", {
+  # Registering SerialParam runs the per-sample delayed operation
+  # (.extract_RIC_and_TIS_fun_extract) in this same process, so covr can
+  # instrument it -- it would otherwise run invisibly inside a forked worker.
+  old_bpparam <- BiocParallel::bpparam()
+  BiocParallel::register(BiocParallel::SerialParam())
+  on.exit(BiocParallel::register(old_bpparam))
+
+  ds <- make_dataset()
+
+  tis <- getTIS(ds)
+  ric <- getRIC(ds)
+
+  expect_equal(dim(tis), c(2L, 201L))
+  expect_equal(dim(ric), c(2L, 101L))
+  expect_equal(dimnames(tis)[[1]], c("s1", "s2"))
+})
+
+test_that("plotTIS() returns a ggplot with one line per sample over the full drift time range by default", {
+  ds <- make_dataset()
+
+  p <- plotTIS(ds)
+
+  expect_s3_class(p, "ggplot")
+  expect_equal(p$labels$x, "Drift time (ms)")
+  expect_equal(p$labels$y, "TIS Intensity (a.u.)")
+  expect_setequal(as.character(unique(p$layers[[1]]$data$SampleID)), c("s1", "s2"))
+  expect_equal(range(p$layers[[1]]$data$drift_time_ms), c(0, 4))
+})
+
+test_that("plotTIS() restricts to dt_range and a single sample when given", {
+  ds <- make_dataset()
+
+  p <- plotTIS(ds, dt_range = c(1, 3), sample = "s1")
+
+  expect_equal(as.character(unique(p$layers[[1]]$data$SampleID)), "s1")
+  expect_equal(range(p$layers[[1]]$data$drift_time_ms), c(1, 3))
+})
+
+test_that("plotRIC() returns a ggplot with one line per sample over the full retention time range by default", {
+  ds <- make_dataset()
+
+  p <- plotRIC(ds)
+
+  expect_s3_class(p, "ggplot")
+  expect_equal(p$labels$x, "Retention time (s)")
+  expect_equal(p$labels$y, "RIC Intensity (a.u.)")
+  expect_setequal(as.character(unique(p$layers[[1]]$data$SampleID)), c("s1", "s2"))
+})
+
+test_that("plotRIC() restricts to rt_range and a single sample when given", {
+  ds <- make_dataset()
+
+  p <- plotRIC(ds, rt_range = c(10, 30), sample = 1)
+
+  expect_equal(as.character(unique(p$layers[[1]]$data$SampleID)), "s1")
+  expect_equal(range(p$layers[[1]]$data$retention_time_s), c(10, 30))
+})


### PR DESCRIPTION
## Summary
- `alignPlots()`: tests the three returned ggplot objects (rt/dt correction plots and the dt_kcorr plot) for labels and expected data, reusing the existing `align()` fixture in `test-align-GCIMSDataset.R`.
- `getTIS()`/`getRIC()`: tests the extracted TIS/RIC matrices' shape and SampleID-keyed dimnames.
- `plotTIS()`/`plotRIC()`: tests labels, data, and the `dt_range`/`rt_range` and `sample=` filtering — same "inspect the returned ggplot object, don't render it" strategy used for the other plot functions in #49.

## A useful technique for BiocParallel-forked code
Registering `BiocParallel::SerialParam()` locally in a test (instead of the default forking `MulticoreParam`) runs a delayed operation's per-sample step in the same process, letting `covr` instrument code that would otherwise run invisibly inside a forked worker. Used this for two tests here to unlock coverage on `.align_fun_extract()`'s `dt_kcorr` fallback and `.extract_RIC_and_TIS_fun_extract()` — both were already being exercised by existing/new tests, just invisible to `covr` until now. This is likely reusable for the similar BiocParallel-fork gaps noted in earlier coverage PRs (e.g. in `aaa-class-DelayedDatasetDisk.R`).

Brings `getTIS_getRIC-GCIMSDataset.R` to 100% line coverage, and `align-GCIMSDataset.R` to 97.5% (116/119) — the remaining 3 lines are the `pow` package's optional reference-selection call (needs that package installed) and two `eval_poly()` branches inside `alignPlots()` that are dead code given its only caller always passes a 2-column matrix.

Overall package coverage: 86.83% → 90.21%.

## Test plan
- [x] Ran both test files individually — all pass
- [x] Full suite `testthat::test_local(".")` — 701 passing, 1 pre-existing skip, 0 failures
- [x] `covr::package_coverage()` confirms the reported numbers


---
_Generated by [Claude Code](https://claude.ai/code/session_019V3CHRGSzcEu3k6tpUFv56)_