### PR TITLE
Cover align-GCIMSSample.R and utils-io-mea.R edge cases; fix wrong unit in read_mea() error

### DIFF
--- a/R/utils-io-mea.R
+++ b/R/utils-io-mea.R
@@ -176,7 +176,7 @@ read_mea <- function(filename) {
   } else if (params[["Chunk trigger repetition"]][["unit"]] == "s") {
     retention_time_step_s <- params[["Chunk trigger repetition"]][["value"]]
   } else {
-    stop(sprintf("Expected Chunk trigger repetition to be in ms, found %s instead. Please open an issue to implement this", params[["Chunk sample rate"]][["unit"]]))
+    stop(sprintf("Expected Chunk trigger repetition to be in ms, found %s instead. Please open an issue to implement this", params[["Chunk trigger repetition"]][["unit"]]))
   }
   ret_time_step <- (params[['Chunk averages']] + 1)*retention_time_step_s
   ret_time <- seq(from = 0.0, by = ret_time_step, length.out = params[["Chunks count"]])

--- a/tests/testthat/test-align-GCIMSSample.R
+++ b/tests/testthat/test-align-GCIMSSample.R
@@ -183,3 +183,79 @@ test_that("align aborts instead of silently returning an empty/all-NA sample", {
     "missing values"
   )
 })
+
+test_that("align aborts when the data is already entirely missing before subsetting", {
+  s <- GCIMSSample(drift_time = 1:2, retention_time = 1:10, data = matrix(NA_real_, nrow = 2, ncol = 10))
+
+  expect_error(
+    align(s, method_rt = "none", ric_ref = rep(1, 10), ric_ref_rt = 1:10),
+    "After aligning retention time"
+  )
+})
+
+test_that("alignDt truncates dt_max_ms when the correction shrinks the high end of the drift time axis", {
+  dt <- seq(1, 10, by = 0.5)
+  rt <- 1:20
+  rip_idx <- 10 # dt[10] == 5.5
+  s <- make_rip_sample(dt, rt, rip_idx)
+
+  # rip_ref_ms < dt[rip_idx] gives Kcorr < 1, so dt_corr shrinks below dt_end:
+  aligned <- alignDt(s, rip_ref_ms = 3)
+
+  expect_lt(aligned@proc_params$align$dt_kcorr, 1)
+  expect_lt(aligned@proc_params$align$dt_max_ms, max(dt))
+})
+
+test_that("prealign aborts when drift-time alignment yields an all-NA sample", {
+  # alignDt() cannot naturally produce an all-NA sample through the public
+  # API (it interpolates with extrap = TRUE), so this defensive check is
+  # forced by mocking alignDt() directly.
+  testthat::local_mocked_bindings(
+    alignDt = function(object, rip_ref_ms) {
+      object@data[] <- NA_real_
+      object@proc_params$align <- list(
+        dt_kcorr = 1, dt_min_ms = min(dtime(object)), dt_max_ms = max(dtime(object))
+      )
+      object
+    },
+    .package = "GCIMS"
+  )
+  s <- make_rip_sample(1:2, 1:10, rip_idx = 1)
+
+  expect_error(
+    prealign(s, align_dt = TRUE, align_ip = FALSE, rip_ref_ms = 1, min_start = 1, rt_ref = 1:5),
+    "After aligning drift times"
+  )
+})
+
+test_that("prealign aborts when the post-alignment subset leaves no data", {
+  # None of prealign()'s own dt_range/rt_range computations can naturally
+  # produce an empty/all-NA subset through the public API, so this
+  # defensive check is forced by mocking subset.GCIMSSample() directly.
+  testthat::local_mocked_bindings(
+    subset.GCIMSSample = function(x, ...) {
+      x@data[] <- NA_real_
+      x
+    },
+    .package = "GCIMS"
+  )
+  s <- make_rip_sample(1:2, 1:10, rip_idx = 1)
+
+  expect_error(
+    prealign(s, align_dt = FALSE, align_ip = FALSE, rip_ref_ms = 1, min_start = 1, rt_ref = 1:5),
+    "After aligning and subsetting"
+  )
+})
+
+test_that("alignRt_ptw truncates rt_max_s when the correction shrinks the high end of the retention time axis", {
+  dt <- 1:2
+  rt <- 1:60
+
+  ref_sample <- make_bump_sample(dt, rt, center = 30)
+  ric_ref <- getRIC(ref_sample)
+  shifted_sample <- make_bump_sample(dt, rt, center = 45)
+
+  aligned <- alignRt_ptw(shifted_sample, ric_ref = ric_ref, ric_ref_rt = rt)
+
+  expect_lt(aligned@proc_params$align$rt_max_s, max(rt))
+})

--- a/tests/testthat/test-read_mea.R
+++ b/tests/testthat/test-read_mea.R
@@ -3,3 +3,109 @@ test_that("read_mea does not crash", {
   sample <- read_mea(mea_file)
   expect_s4_class(sample, "GCIMSSample")
 })
+
+test_that("read_mea rejects files without a .mea/.mea.gz extension", {
+  expect_error(read_mea("not_a_mea_file.txt"), "\\.mea or \\.mea\\.gz file")
+})
+
+test_that("read_mea uses the name of a named filename argument as the description", {
+  mea_file <- system.file("extdata/sample_formats/small.mea.gz", package = "GCIMS")
+
+  sample <- read_mea(c(myname = mea_file))
+
+  expect_equal(description(sample), "myname")
+})
+
+# Fixture: decompress the bundled small.mea.gz sample, split its header into
+# lines, and provide helpers to patch individual "Key = value [unit]" lines
+# and re-serialize a synthetic, uncompressed .mea file with the same binary
+# spectrum data. Used to exercise read_mea()'s unit-validation branches,
+# which the single bundled sample file can't reach on its own.
+mea_header_fixture <- function() {
+  mea_file <- system.file("extdata/sample_formats/small.mea.gz", package = "GCIMS")
+  con <- gzfile(mea_file, "rb")
+  raw_bytes <- readBin(con, what = "raw", n = 50 * 1024 * 1024)
+  close(con)
+  nul_idx <- which(raw_bytes == as.raw(0))[1]
+  header_text <- iconv(rawToChar(raw_bytes[1:(nul_idx - 1)]), from = "windows-1252", to = "UTF-8")
+  list(
+    lines = strsplit(header_text, "\n", fixed = TRUE)[[1]],
+    rest = raw_bytes[nul_idx:length(raw_bytes)]
+  )
+}
+
+replace_mea_header_line <- function(lines, key, new_line) {
+  idx <- which(startsWith(trimws(lines), key))
+  stopifnot(length(idx) == 1)
+  lines[idx] <- new_line
+  lines
+}
+
+write_mea_from_lines <- function(lines, rest, path = tempfile(fileext = ".mea")) {
+  header_raw <- iconv(paste(lines, collapse = "\n"), from = "UTF-8", to = "windows-1252", toRaw = TRUE)[[1]]
+  writeBin(c(header_raw, rest), path)
+  path
+}
+
+test_that("read_mea errors clearly when Chunk sample rate isn't in kHz", {
+  fx <- mea_header_fixture()
+  lines <- replace_mea_header_line(fx$lines, "Chunk sample rate", "Chunk sample rate              = 150 [Hz]")
+  mea_file <- write_mea_from_lines(lines, fx$rest)
+
+  expect_error(read_mea(mea_file), "Expected Chunk sample rate to be in kHz, found Hz instead")
+})
+
+test_that("read_mea accepts Chunk trigger repetition in seconds", {
+  fx <- mea_header_fixture()
+  lines <- replace_mea_header_line(
+    fx$lines, "Chunk trigger repetition", "Chunk trigger repetition       = 0.03 [s]"
+  )
+  mea_file <- write_mea_from_lines(lines, fx$rest)
+
+  sample_s <- read_mea(mea_file)
+  sample_ms <- read_mea(system.file("extdata/sample_formats/small.mea.gz", package = "GCIMS"))
+
+  expect_equal(rtime(sample_s), rtime(sample_ms))
+})
+
+test_that("read_mea errors clearly when Chunk trigger repetition isn't in ms or s", {
+  fx <- mea_header_fixture()
+  lines <- replace_mea_header_line(
+    fx$lines, "Chunk trigger repetition", "Chunk trigger repetition       = 0.0005 [min]"
+  )
+  mea_file <- write_mea_from_lines(lines, fx$rest)
+
+  expect_error(read_mea(mea_file), "Expected Chunk trigger repetition to be in ms, found min instead")
+})
+
+test_that("read_mea accepts a drift tube length given in mm", {
+  fx <- mea_header_fixture()
+  lines <- replace_mea_header_line(fx$lines, "nom Drift Tube Length", "nom Drift Tube Length          = 98 [mm]")
+  mea_file <- write_mea_from_lines(lines, fx$rest)
+
+  sample <- read_mea(mea_file)
+
+  expect_equal(sample@drift_tube_length, 98)
+})
+
+test_that("read_mea errors clearly for an unrecognized drift tube length unit", {
+  fx <- mea_header_fixture()
+  lines <- replace_mea_header_line(fx$lines, "nom Drift Tube Length", "nom Drift Tube Length          = 98 [cm]")
+  mea_file <- write_mea_from_lines(lines, fx$rest)
+
+  expect_error(read_mea(mea_file), "Unit conversion cm->mm not implemented")
+})
+
+test_that("read_mea warns once and keeps the raw value for an unrecognized header key", {
+  fx <- mea_header_fixture()
+  # A single long padding line pushes the header past match_raw()'s 8192-byte
+  # scan slice, exercising its multi-slice loop as a side effect.
+  padding_value <- paste(rep("X", 9000), collapse = "")
+  lines <- c(fx$lines, sprintf('PaddingKey                     = "%s"', padding_value))
+  mea_file <- write_mea_from_lines(lines, fx$rest)
+
+  expect_warning(sample <- read_mea(mea_file), "Unknown key: PaddingKey")
+
+  expect_s4_class(sample, "GCIMSSample")
+  expect_equal(dim(intensity(sample)), c(1670L, 530L))
+})

--- a/tests/testthat/test-write_mea.R
+++ b/tests/testthat/test-write_mea.R
@@ -25,3 +25,26 @@ test_that("read, write, read mea file to get the same object", {
   file.remove(mea_file)
 })
 
+test_that("write_mea validates the filename argument", {
+  obj <- GCIMSSample(drift_time = 0:1, retention_time = 0:2, data = matrix(1:6, nrow = 2, ncol = 3))
+
+  expect_error(write_mea(obj, 123), "filename should be a string")
+  expect_error(write_mea(obj, c("a", "b")), "filename should be of length one")
+})
+
+test_that("write_mea gzip-compresses when given a .mea.gz filename, and appends .mea otherwise", {
+  obj <- GCIMSSample(drift_time = 0:1, retention_time = 0:2, data = matrix(1:6, nrow = 2, ncol = 3))
+
+  gz_file <- tempfile(fileext = ".mea.gz")
+  write_mea(obj, gz_file)
+  expect_true(file.exists(gz_file))
+  obj_gz <- read_mea(gz_file)
+  expect_equal(intensity(obj_gz), intensity(obj))
+  file.remove(gz_file)
+
+  no_ext_file <- tempfile()
+  write_mea(obj, no_ext_file)
+  expect_true(file.exists(paste0(no_ext_file, ".mea")))
+  file.remove(paste0(no_ext_file, ".mea"))
+})
+


### PR DESCRIPTION
align-GCIMSSample.R: tests the all-NA-before-subsetting aborts in align()
and prealign() (the latter forced via local_mocked_bindings, since
alignDt()/subset.GCIMSSample() can't naturally produce an all-NA result
through the public API), and the dt_max_ms/rt_max_s high-end truncation
branches in alignDt()/alignRt_ptw() (triggered with a correction that
shrinks, rather than grows, the axis).

utils-io-mea.R: tests read_mea()'s extension guard, named-filename
description, and its Chunk-sample-rate/Chunk-trigger-repetition/drift-tube
unit validation branches, using a fixture that patches individual header
lines of the bundled small.mea.gz sample and re-serializes a synthetic
.mea file with the same binary data. Also tests write_mea()'s filename
validation and its .mea.gz/extension-appending branches.

Fixes a copy-paste bug found via the above: the "Chunk trigger repetition"
unit-validation error reported params[["Chunk sample rate"]]'s unit
(always "kHz") instead of the actual invalid unit.