### PR TITLE
Fix silent codecov upload failures by authenticating with a repo token

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -298,6 +298,8 @@ jobs:
 
       - name: Test coverage
         if: github.ref == 'refs/heads/master' && env.run_covr == 'true' && runner.os == 'Linux' && env.CONF_NAME == 'ubuntu'
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           covr::codecov()
         shell: Rscript {0}


### PR DESCRIPTION
## Summary
- Every recent push to `master`'s "Test coverage" step has been hitting Codecov's HTTP 429 rate limit for tokenless uploads. The job logs show: `"Rate limit reached. Please upload with the Codecov repository upload token to resolve issue."`
- The step still reports success in CI, because `covr::codecov()` doesn't fail the step on a bad HTTP response — it just prints the error body. So coverage uploads have been silently broken.
- Fix: pass `CODECOV_TOKEN` from a repo secret to the step's environment. `covr::codecov()` already knows to read this env var to authenticate the upload.

## Requires a follow-up step outside this PR
This won't take effect until a `CODECOV_TOKEN` secret exists on the repo. Get it from codecov.io (the `sipss/GCIMS` repo's settings → upload token) and add it at `github.com/sipss/GCIMS/settings/secrets/actions`.

## Test plan
- [x] Validated the updated `check-bioc.yml` parses as valid YAML
- [ ] Confirm the next push to `master` (after the `CODECOV_TOKEN` secret is added) uploads to Codecov without a 429

---
_Generated by [Claude Code](https://claude.ai/code/session_019V3CHRGSzcEu3k6tpUFv56)_